### PR TITLE
Agrego pruebas y archivos para el requerimiento stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stackName", (request, response) => {
+    const stack = request.params.stackName;
+    const explorersWithStack = ExplorerController.getExplorersByStack(stack);
+    response.status(200).json(explorersWithStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,8 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+
+describe("Tests para ExplorerController", () => {
+    test("Requerimiento 1: Obtener explorers que cuenten con un stack", () => {
+        const explorersWithStack = ExplorerController.getExplorersByStack("javascript");
+        expect(explorersWithStack.length).toBe(11);
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,9 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Obtener explorers que cuenten con un stack", () => {
+        const explorers = [{stacks: ["javascript", "elm"]}, {stacks: []}, {stacks: ["elixir", "javascript"]}, {stacks: ["groovy", "java", "elixir", "javascript"]}, {stacks: ["elm", "elixir"]},];
+        const explorersWithStack = ExplorerService.filterByStack(explorers, "javascript");
+        expect(explorersWithStack.length).toBe(3);
+    });
 });


### PR DESCRIPTION
Agregué las pruebas y modificaciones necesarias en los archivos *ExplorerService.js*, *ExplorerController.js*, y *server.js* para poder regresar toda la lista de explorers filtrados por un stack.

Para realizar la funcionalidad del requisito utilicé la lógica del método `filterByMission()` de la clase `ExplorerService`.
Solo que a diferencia de filtrar por operador de igualdad (`==`) utilice el método `includes` para verificar que la lista de stacks de los explorers incluyese el stack deseado.

E.g.:
```javascript
// filterByMission()
explorer.mission == "node";

// filterByStack()
explorer.stacks.includes("javascript");
```