### PR TITLE
Explorers Filtrados por Stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -22,9 +22,9 @@ class ExplorerController{
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
 
-    static getFilterByStack(mision){
+    static getFilterByStack(stack){
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByStack(explorers, mision);
+        return ExplorerService.filterByStack(explorers, stack);
     }
 }
 

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getFilterByStack(mision){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, mision);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -3,6 +3,7 @@ const FizzbuzzService = require("../services/FizzbuzzService");
 const Reader = require("../utils/reader");
 
 class ExplorerController{
+    
     static getExplorersByMission(mission){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.filterByMission(explorers, mission);

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,6 +26,12 @@ app.get("/v1/explorers/usernames/:mission", (request, response) => {
     response.json({mission: request.params.mission, explorers: explorersUsernames});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersByStack = ExplorerController.getFilterByStack(stack);
+    response.json({stack, explorers: explorersByStack});
+});
+
 app.get("/v1/fizzbuzz/:score", (request, response) => {
     const score = parseInt(request.params.score);
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack) {
+        return explorers.filter((explorer) => explorer.stacks.includes(stack));
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest",
     "linter": "node ./node_modules/eslint/bin/eslint.js",
     "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
     "server": "node ./lib/server.js"

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,27 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Retornar los explorers del stack indicado", () => {
+        const explorers = [
+            {
+                "name": "Woopa1",
+                "stacks": ["javascript", "reasonML", "elm"]
+            },
+            {
+                "name": "Woopa2",
+                "stacks": ["javascript", "groovy", "elm"]
+            },
+            {
+                "name": "Woopa3",
+                "stacks": ["elixir", "groovy", "reasonML"]
+            },
+            {
+                "name": "Woopa4",
+                "stacks": ["javascript"]
+            }
+        ];
+
+        expect(ExplorerService.filterByStack(explorers, "javascript").length).toBe(3);
+    });
+
 });


### PR DESCRIPTION
**Paso 1: Corregir test de jest para Windows**
- Para poder utilizar jest en Windows se corrige el comando del script en package.json

**Paso 2: Prueba Unitaria para ExplorerService.filterByStack(explorer, stack)**
- Se crea la prueba unitaria para el nuevo requerimiento. Se define un arreglo con cuatro explorers emulando el archivo de explorers.json. Este arreglo está conformado por _name_ y _stacks_ el cual está conformado por una lista de tecnologías. De acuerdo con las tecnologías listadas aquí se devolverá o no el elemento si cumple con la condición de que uno de sus elementos sea igual a _stack_.

**Paso 3: ExplorerService.filterByStack(explorers, stack), retorna los explorers con el stack enviado.**
- Aquí se establece la lógica de _.filterByStack(explorers, stack)_, se utiliza la función filter para que el JSON con los explorers para generar un array que contendrá los explorers que contengan en su propiedad _stacks_ el elemento de _stack_.

**Paso 4: Se agrega getFilterByStack en ExplorerController, desde aquí se envía el JSON de los explorers.**
- El método estático getFilterByStack recibirá como parámetro la cadena del stack deseado. Haciendo uso de Reader se lee el archivo "explorers.json". Se retornará el resultado de la ejecución de ExplorerService.filterByStack y recibirá la contante explorers con la información del JSON, en stack recibirá la cadena del stack deseado cuando se mande a llamar ExplorerController.getFilterByStack(stack).

**Paso 5: Se agrega el Endpoint /v1/explorers/stack/:stack**
- Se agrega el endpoint en la dirección _/v1/explorers/stack/:stack_. Se define _const stack_ que leerá el parámetro de stack recibido en la URL. Además se define _const explorersByStack_ que llamará _ExplorerController.getFilterByStack(stack)_, aquí se recibe el parámetro pasado desde la URL y de esta forma se hace dinámico. Con _response.json({stack, explorers: explorersByStack})_ se muestra el contenido JSON de los explorers que en su stack contienen determinada tecnología.

**Paso 6 y Paso 6.1**
- Paso 6 corrige el nombre de parámetros y el Paso 6.1 hace cambios mínimos (se agrega un espacio) para poder hacer un nuevo commit y push del repositorio y se ejecute GitHub Actions.