### PR TITLE
Agregando funcionalidad para filtrado por Stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+*.swp

--- a/StackFilter.md
+++ b/StackFilter.md
@@ -1,0 +1,32 @@
+## Requerimiento: Agregar servicio de filtro de Explorers por Stack
+
+Se agregar lógica para agregar un filtro por stack, para ello se realizaron las siguientes modificaciones:
+
+## ExplorerService
+
+Se agrega método **getExplorersByStack** donde se utiliza un filter y se aplica la propiedad contains al array **stacks**
+
+```javascript
+explorers.filter((explorer) => explorer.stacks.includes(stack))
+```
+
+## ExplorerService.test
+
+Se agrega las pruebas para verificar el método **getExplorersByStack** del ExplorerService, donde se verifica la cantidad de resultados obtenidos, así como verificar que cada uno de los resultados contenga el stack experado.
+
+## ExplorerController
+
+Se agrega el método **getExplorersByStack**, donde se carga los explorers y se llama al método **getExplorersByStack** del ExplorerService 
+
+## Server
+
+Se agrega endpoint de acceso para el requerimiento, y se utiliza el método **getExplorersByStack** del ExplorerController.
+
+El resultado de la llamada al endpoint es un objeto json similar al siguiente:
+
+```json
+{stack: <stack_recibido>, explorers: [...explorers]}
+```
+
+
+

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,6 +26,12 @@ app.get("/v1/explorers/usernames/:mission", (request, response) => {
     response.json({mission: request.params.mission, explorers: explorersUsernames});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorers = ExplorerController.getExplorersByStack(stack);
+    response.json({stack: stack, explorers: explorers});
+});
+
 app.get("/v1/fizzbuzz/:score", (request, response) => {
     const score = parseInt(request.params.score);
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,18 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento nuevo filtro: regresa todos los explorers que cuenten con un stack", () => {
+        const explorers = [{stacks:["javascript", "node", "elixir"]},{stacks:["elixir"]},{stacks:["javascript"]}];
+        const explorersInJavascript = ExplorerService.getExplorersByStack(explorers, "javascript");
+        expect(explorersInJavascript.length).toBe(2);
+        for(let explorer of explorersInJavascript){
+            expect(explorer.stacks).toContain("javascript");
+        }
+        const explorersInElixir = ExplorerService.getExplorersByStack(explorers, "elixir");
+        expect(explorersInElixir.length).toBe(2);
+        for(let explorer of explorersInElixir){
+            expect(explorer.stacks).toContain("elixir");
+        }
+    });
+
 });


### PR DESCRIPTION
## Requerimiento: Agregar servicio de filtro de Explorers por Stack

Se agregar lógica para agregar un filtro por stack, para ello se realizaron las siguientes modificaciones:

## ExplorerService

Se agrega método **getExplorersByStack** donde se utiliza un filter y se aplica la propiedad contains al array **stacks**

```javascript
explorers.filter((explorer) => explorer.stacks.includes(stack))
```

## ExplorerService.test

Se agrega las pruebas para verificar el método **getExplorersByStack** del ExplorerService, donde se verifica la cantidad de resultados obtenidos, así como verificar que cada uno de los resultados contenga el stack experado.

## ExplorerController

Se agrega el método **getExplorersByStack**, donde se carga los explorers y se llama al método **getExplorersByStack** del ExplorerService 

## Server

Se agrega endpoint de acceso para el requerimiento, y se utiliza el método **getExplorersByStack** del ExplorerController.

El resultado de la llamada al endpoint es un objeto json similar al siguiente:

```json
{"stack": "<stack_recibido>", "explorers": [...explorers]}
```
