### PR TITLE
Agregando nuevo metodo de filtrado por stack

### DIFF
--- a/Ejecucion
+++ b/Ejecucion
@@ -1,0 +1,11 @@
+- Primero se creo al prueba de unidad que nos permitiria conocer el buen funcionamiento del metodo deseado
+
+- Tras crear la prueba se ideo la manera de filtrar la lista de explorers que contuviera el stack deseado, siendo el stack una entrada por parte del usuario para que busque tantos    stacks como guste
+
+- Para lo anterior utilice una idea similar a lo que se hizo con el filtrado de explorers por mision (ExporerService.filterByMission) solo que con el agregado del metodo '.include' para asegurarnos que tomo solo aquellos que contiene el stack que se busca
+
+- Dado que lo que nos interesa es solo el nombre de usuario se hizo uso de '.map' para quedarnos solamente con el nombre de usuario del epxlorer
+
+- Despues de hacer esto y ver que a prueba funcionara se creo en ExploerController un metodo que llamase al metodo antes descrito
+
+- Posteriormente se creo el endpoint con el cual se puede acceder a esta informacion, en dicho endpint se coloca el stack de interes para que el api nos despliegue la informacion que deseamos

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,12 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersStacks(explorers, stack);
+    }
+
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersByStack = ExplorerController.getExplorersByStack(stack);
+    response.json({explorersByStack});
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -18,8 +18,8 @@ class ExplorerService {
 
     static getExplorersStacks(explorers, stack){
         const StackExplorer = explorers.filter((explorer) => explorer.stacks.includes(stack));
-        const StackExplorerUsername = StackExplorer.map((explorer) => explorer.githubUsername)
-        return StackExplorerUsername
+        const StackExplorerUsername = StackExplorer.map((explorer) => explorer.githubUsername);
+        return StackExplorerUsername;
     }
 
 }

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,12 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersStacks(explorers, stack){
+        const StackExplorer = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        const StackExplorerUsername = StackExplorer.map((explorer) => explorer.githubUsername)
+        return StackExplorerUsername
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
-    "linter": "node ./node_modules/eslint/bin/eslint.js",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "linter": "node ./node_modules/eslint/bin/eslint.js .",
     "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
     "server": "node ./lib/server.js"
   },

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -11,6 +11,6 @@ describe("Tests para ExplorerService", () => {
         const example = [{"githubUsername": "ajolonauta15","stacks": ["javascript", "elixir", "groovy", "reasonML", "elm"]}, {"githubUsername": "ajolonauta14",  "stacks": ["elm"]}];
         const UsernameByStacks = ExplorerService.getExplorersStacks(example, "elixir");
         expect(UsernameByStacks[0]).toMatch(/ajolonauta15/);
-    });
+    }); 
 
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,10 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("4. Looks for stack", () => {
+        const example = [{"githubUsername": "ajolonauta15","stacks": ["javascript", "elixir", "groovy", "reasonML", "elm"]}, {"githubUsername": "ajolonauta14",  "stacks": ["elm"]}];
+        const UsernameByStacks = ExplorerService.getExplorersStacks(example, "elixir");
+        expect(UsernameByStacks[0]).toMatch(/ajolonauta15/);
+    });
+
 });


### PR DESCRIPTION
En este commit agregue la prueba necesaria correspondtiente al metodo metodo que busca el nombre de usuario de los explorers por stack de interes, las pruebas al ser agregadas a github corrieron de manera exitosa