### PR TITLE
Get Explorers By Stack Pull Request

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        const stackers = ExplorerService.getExplorersByStack(explorers, stack);
+        return stackers;
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,6 +26,12 @@ app.get("/v1/explorers/usernames/:mission", (request, response) => {
     response.json({mission: request.params.mission, explorers: explorersUsernames});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersNamesWithStack = ExplorerController.getExplorersByStack(stack);
+    response.json({stack: request.params.stack, explorers: explorersNamesWithStack});
+});
+
 app.get("/v1/fizzbuzz/:score", (request, response) => {
     const score = parseInt(request.params.score);
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,7 +15,10 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
-
+    static getExplorersByStack(explorers, stack) {
+        const explorersByStack = explorers.filter((explorer) => explorer["stacks"].includes(stack));
+        return explorersByStack.map((explorer) => explorer.name);
+    }
 }
 
 module.exports = ExplorerService;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
+    "test": "node ./node_modules/jest/bin/jest.js",
     "linter": "node ./node_modules/eslint/bin/eslint.js",
     "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
     "server": "node ./lib/server.js"

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,11 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+
+describe("Test suit for ExplorerController", () => {
+    test(" Test for getExplorersByStack method in explorer controller", () => {
+        const elixsers = ExplorerController.getExplorersByStack("elixir");
+        const jsers = ExplorerController.getExplorersByStack("javascript");
+
+        expect(jsers[0]).toBe("Woopa1");
+        expect(elixsers[0]).toBe("Woopa3");
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,5 +6,14 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
+    test("Explorers by stack", () => {
+        const explorers = [{"name": "Woopa1","stacks": ["javascript","reasonML","elm"]},
+          {"name": "Woopa2","stacks": ["javascript","groovy","elm"]},
+          {"name": "Woopa3","stacks": ["elixir","groovy","reasonML"]}]
+        const elixsers = ExplorerService.getExplorersByStack(explorers, "elixir");
+        const jsers = ExplorerService.getExplorersByStack(explorers, "javascript");
 
+        expect(jsers[0]).toBe("Woopa1");
+        expect(elixsers[0]).toBe("Woopa3");
+    });
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -8,8 +8,8 @@ describe("Tests para ExplorerService", () => {
     });
     test("Explorers by stack", () => {
         const explorers = [{"name": "Woopa1","stacks": ["javascript","reasonML","elm"]},
-          {"name": "Woopa2","stacks": ["javascript","groovy","elm"]},
-          {"name": "Woopa3","stacks": ["elixir","groovy","reasonML"]}]
+            {"name": "Woopa2","stacks": ["javascript","groovy","elm"]},
+            {"name": "Woopa3","stacks": ["elixir","groovy","reasonML"]}];
         const elixsers = ExplorerService.getExplorersByStack(explorers, "elixir");
         const jsers = ExplorerService.getExplorersByStack(explorers, "javascript");
 


### PR DESCRIPTION
### Saludos mi estimado MC
Le presento mi pr para implementar 
### ExplorerService
El método getExplorersByStack en ExplorerService recibe como argumentos un objeto y la cadena de texto del stack que se desea buscar, este método filtra el objeto si contiene el stack dentro del arreglo en el mismo y procede a almacenar el nombre (no el nombre de usuario) en un arreglo.
Este proceso cuenta con su respectiva prueba.
### ExplorerController
El método getExplorersByStack en ExplorerController ahora solo toma como argumento el stack deseado y dentro del método estático se define que deberá leer explorers.json, el método es exportado desde ExplorerService y utilizado de la misma manera.
Este proceso tambien cuenta con su respectiva prueba.
### Server
En este archivo se implementa un método GET en la ruta "/v1/explorers/stack/" que toma como parámetro ":stack", implementa entonces el método "getExplorersByStack" de "ExplorerController" agregando el parametro stack y este regresa un objeto con el nombre del stack y un arreglo de los nombres (no nombres de usuario) de los explorers que contienen el stack solicitado en su stack.
### Apuntes
Modifiqué la instalación de jest para probar que funcionaran las pruebas, por eso marca la diferencia en el directório