### PR TITLE
Filtering by stack endpoint

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("v1/explorers/stack/:stack",(request, respsonse) => {
+
+    response.json({});
+
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,9 +32,10 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
-app.get("v1/explorers/stack/:stack",(request, respsonse) => {
-
-    response.json({});
+app.get("/v1/explorers/stack/:stack",(request, response) => {
+    const stack = request.params.stack;
+    const explorersByStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorersByStack);
 
 });
 

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -17,7 +17,7 @@ class ExplorerService {
     }
 
     static filterByStack(explorers, stack) {
-        const explorersByStack = explorers.filter((explorer)=>explorer.stacks.include(stack));
+        const explorersByStack = explorers.filter((explorer)=>explorer.stacks.includes(stack));
 
         return explorersByStack;
     }

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,12 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack) {
+        const explorersByStack = explorers.filter((explorer)=>explorer.stacks.include(stack));
+
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,20 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test(" get explorers by stack",() => {
+        const explorers = [
+            {
+                "name": "Woopa1",
+                "githubUsername": "ajolonauta1",
+                "score": 1,
+                "mission": "node",
+                "stacks": [
+                    "javascript",
+                    "reasonML",
+                    "elm"
+                ],
+            }];
+        const explorersByStack = ExplorerService.filterByStack(explorers,"javascript");
+        expect(explorersByStack).toStrictEqual(explorers);
+    });
 });


### PR DESCRIPTION
# Endpoint for filtering by stack.

this endpoint filters explorers.json by stack

endpoint added:

> GET http://localhost:3000/explorers/stack/{stack}

unit test added for testing filterByStack method from Explorer service

- code linted properly