### PR TITLE
Creación de nuevo endpoint para filtrar la lista de explorers por su contenido en stacks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,7 +10,6 @@ module.exports = {
         "ecmaVersion": "latest"
     },
     "rules": {
-        "no-unused-vars": "off",
         indent: ["error", 4],
         "linebreak-style": ["error", "unix"],
         quotes: ["error", "double"],

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -3,25 +3,51 @@ const FizzbuzzService = require("../services/FizzbuzzService");
 const Reader = require("../utils/reader");
 
 class ExplorerController{
+
+    /**
+     * 
+     * @param {string} mission 
+     * @returns Explorers Filter By MIssion
+     */
     static getExplorersByMission(mission){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.filterByMission(explorers, mission);
     }
 
+    /**
+     * 
+     * @param {string} score 
+     * @returns validation number with fizzbuzz
+     */
     static applyFizzbuzz(score){
         return FizzbuzzService.applyValidationInNumber(score);
     }
 
+    /**
+     * 
+     * @param {string} mission 
+     * @returns Explorer's username by mission
+     */
     static getExplorersUsernamesByMission(mission){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getExplorersUsernamesByMission(explorers, mission);
     }
 
+    /**
+     * 
+     * @param {string} mission 
+     * @returns Explorers Amount filter by mission
+     */
     static getExplorersAmonutByMission(mission){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
 
+    /**
+     * 
+     * @param {string} stack 
+     * @returns Explorer sFilter By Stack
+     */
     static getExplorersByStack(stack){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.filterByStack(explorers, stack);

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stacks/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersWithStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorersWithStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -1,21 +1,45 @@
 class ExplorerService {
 
+    /**
+     * 
+     * @param {explorersObject} explorers 
+     * @param {string} mission 
+     * @returns explorers filter by mission
+     */
     static filterByMission(explorers, mission){
         const explorersByMission = explorers.filter((explorer) => explorer.mission == mission);
         return explorersByMission;
     }
 
+    /**
+     * 
+     * @param {explorersObject} explorers 
+     * @param {string} mission 
+     * @returns explorers amount filter by mission
+     */
     static getAmountOfExplorersByMission(explorers, mission){
         const explorersByMission = ExplorerService.filterByMission(explorers, mission);
         return explorersByMission.length;
     }
 
+    /**
+     * 
+     * @param {explorersObject} explorers 
+     * @param {string} mission 
+     * @returns explorer's usernames list
+     */
     static getExplorersUsernamesByMission(explorers, mission){
         const explorersByMission = ExplorerService.filterByMission(explorers, mission);
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
 
+    /**
+     * 
+     * @param {explorersObject} explorers 
+     * @param {string} stack 
+     * @returns explorers filtering by stack
+     */
     static filterByStack(explorers, stack){
         const explorerByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
         return explorerByStack;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack){
+        const explorerByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorerByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
-    "linter": "node ./node_modules/eslint/bin/eslint.js",
-    "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest",
+    "linter": "eslint .",
+    "linter-fix": "eslint . --fix",
     "server": "node ./lib/server.js"
   },
   "keywords": [],

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -12,7 +12,6 @@ describe("Tests para ExplorerService", () => {
         const stack = "javascript";
         const explorerStack = ExplorerService.filterByStack(explorers, stack);
         
-        console.log(explorerStack);
         expect(explorerStack[explorerStack.length-1].stacks).toContain("javascript");
     });
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,13 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento de contribucion, que todos los explorers tengan en su stack un valor", () => {
+        const explorers = [ {username: "Luis",stacks:["javascript", "php", "cobol"]}, {username: "Angel",stacks: ["C#", "python", "elixir"]}, {username: "Luian",stacks: ["C#", "javascript", "elixir"]}];
+        const stack = "javascript";
+        const explorerStack = ExplorerService.filterByStack(explorers, stack);
+        
+        console.log(explorerStack);
+        expect(explorerStack[explorerStack.length-1].stacks).toContain("javascript");
+    });
+
 });


### PR DESCRIPTION
El requerimiento se hizo mediante TDD, por lo cual primero se implemento la prueba unitaria, la cual tendría la lógica y la funcionalidad que se requeria en el endpoint
**Test Unitario**
```js

    test("Requerimiento de contribucion, que todos los explorers tengan en su stack un valor", () => {
        const explorers = [ {username: "Luis",stacks:["javascript", "php", "cobol"]}, {username: "Angel",stacks: ["C#", "python", "elixir"]}, {username: "Luian",stacks: ["C#", "javascript", "elixir"]}];
        const stack = "javascript";
        const explorerStack = ExplorerService.filterByStack(explorers, stack);
        expect(explorerStack[explorerStack.length-1].stacks).toContain("javascript");
    });
```

**Función en ExplorerService**
```js
static filterByStack(explorers, stack){
        const explorerByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
        return explorerByStack;
    }
```


Una vez que el test fue aprobado, se implemento la función en **ExplorerController**

```js
static getExplorersByStack(stack){
        const explorers = Reader.readJsonFile("explorers.json");
        return ExplorerService.filterByStack(explorers, stack);
    } 
```

Una vez implemantada la funcion en el controlador de explorer , se agrego la peticion get en *servidor.js*
```js
app.get("/v1/explorers/stacks/:stack", (request, response) => {
    const stack = request.params.stack;
    const explorersWithStack = ExplorerController.getExplorersByStack(stack);
    response.json(explorersWithStack);
});
```
