### PR TITLE
Agregando un endpoint para que regrese la lista de explorers filtrados por stack.

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -22,9 +22,9 @@ class ExplorerController{
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
 
-    static filterByStack(stack) {
+    static filterByStack(stacks) {
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByStack(explorers, stack);
+        return ExplorerService.filterByStack(explorers, stacks);
     }
 }
 

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static filterByStack(stack) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:value", (req, res) => {
+    const stacks = req.params.value;
+    const listOfExplorers = ExplorerController.filterByStack(stacks);
+    res.status(200).json({listOfExplorers});
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -21,7 +21,7 @@ class ExplorerService {
         const explorersByStack = [];
 
         explorers.forEach( explorer => {            
-            const result = explorer.stack.some( item => item == stack );
+            const result = explorer.stacks.some( item => item == stack );
             if (result) explorersByStack.push(explorer);
         });
 

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -17,10 +17,16 @@ class ExplorerService {
     }
 
     static filterByStack(explorers, stack) {
-        const explorersByStack = explorers.filter( explorer => explorer.stack == stack);
+
+        const explorersByStack = [];
+
+        explorers.forEach( explorer => {            
+            const result = explorer.stack.some( item => item == stack );
+            if (result) explorersByStack.push(explorer);
+        });
+
         return explorersByStack;
     }
-
 }
 
 module.exports = ExplorerService;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -1,7 +1,7 @@
 class ExplorerService {
 
     static filterByMission(explorers, mission){
-        const explorersByMission = explorers.filter((explorer) => explorer.mission == mission);
+        const explorersByMission = explorers.filter( explorer => explorer.mission == mission);
         return explorersByMission;
     }
 
@@ -12,8 +12,13 @@ class ExplorerService {
 
     static getExplorersUsernamesByMission(explorers, mission){
         const explorersByMission = ExplorerService.filterByMission(explorers, mission);
-        const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
+        const explorersUsernames = explorersByMission.map( explorer => explorer.githubUsername);
         return explorersUsernames;
+    }
+
+    static filterByStack(explorers, stack) {
+        const explorersByStack = explorers.filter( explorer => explorer.stack == stack);
+        return explorersByStack;
     }
 
 }

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -13,7 +13,7 @@ describe("Tests para ExplorerService", () => {
             { stack:["python"] }, 
             { stack: ["javascript", "java"] }
         ];
-        const explorersStack = ExplorerService.filterByStack(explorers);
+        const explorersStack = ExplorerService.filterByStack(explorers, 'javascript');
         expect(explorersStack.length).toBe(2)
     })
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -9,19 +9,19 @@ describe("Tests para ExplorerService", () => {
 
     test("Nuevo requerimiento: Obtener una lista de explorers filtrado por Stack", () => {
         const explorers1 = [
-            { stack: ["Node", "javascript"] }, 
-            { stack:["python"] }, 
-            { stack: ["javascript", "java"] }
+            { stacks: ["Node", "javascript"] }, 
+            { stacks:["python"] }, 
+            { stacks: ["javascript", "java"] }
         ];
 
         const explorers2 = [
-            { stack: ["java", "typescript", "javascript"]}, 
-            { stack:["node", "jest"]},
-            { stack: ["javascript", "java"]},
-            { stack: ["ruby", "java", "c"]},
-            { stack: ["elixir", "rust"]},
-            { stack: ["c#", "rust", "c"]},
-            { stack: ["javascript", "node", 'vue']}
+            { stacks: ["java", "typescript", "javascript"]}, 
+            { stacks:["node", "jest"]},
+            { stacks: ["javascript", "java"]},
+            { stacks: ["ruby", "java", "c"]},
+            { stacks: ["elixir", "rust"]},
+            { stacks: ["c#", "rust", "c"]},
+            { stacks: ["javascript", "node", 'vue']}
         ];
 
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,13 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Nuevo requerimiento: Obtener una lista de explorers filtrado por Stack", () => {
+        const explorers = [
+            { stack: ["Node", "javascript"] }, 
+            { stack:["python"] }, 
+            { stack: ["javascript", "java"] }
+        ];
+        const explorersStack = ExplorerService.filterByStack(explorers);
+        expect(explorersStack.length).toBe(2)
+    })
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -8,12 +8,27 @@ describe("Tests para ExplorerService", () => {
     });
 
     test("Nuevo requerimiento: Obtener una lista de explorers filtrado por Stack", () => {
-        const explorers = [
+        const explorers1 = [
             { stack: ["Node", "javascript"] }, 
             { stack:["python"] }, 
             { stack: ["javascript", "java"] }
         ];
-        const explorersStack = ExplorerService.filterByStack(explorers, 'javascript');
-        expect(explorersStack.length).toBe(2)
+
+        const explorers2 = [
+            { stack: ["java", "typescript", "javascript"]}, 
+            { stack:["node", "jest"]},
+            { stack: ["javascript", "java"]},
+            { stack: ["ruby", "java", "c"]},
+            { stack: ["elixir", "rust"]},
+            { stack: ["c#", "rust", "c"]},
+            { stack: ["javascript", "node", 'vue']}
+        ];
+
+
+        const explorersStack1 = ExplorerService.filterByStack(explorers1, 'javascript');
+        expect(explorersStack1.length).toBe(2)
+
+        const explorersStack2 = ExplorerService.filterByStack(explorers2, 'java');
+        expect(explorersStack2.length).toBe(3)
     })
 });


### PR DESCRIPTION
Buenas noches!!

Se agregó el siguiente end point: `/v1/explorers/stack/javascript` para la siguiente feature: obtener una lista de explorers filtrados por un stack de forma dinamica.

Se uso la metodología TDD para diseñar la funcionalidad. En general se siguieron los siguientes pasos:
* En `ExplorerService.test.js` se creo una prueba de unidad de acuerdo a los requerimientos, usando dos listas de objetos para probar que se obtenga la lista deseada y asegurar la calidad de la feature.
* Porteriormente se agrego el método estático` filterByStack` dentro de la `clase ExplorerService `para obtener la lista de explorers
* Despues se Agrego en el controlador` ExplorerCotroller` un metodo para comunicarlo con el servidor.
* Finalmente se probaron los tests nuevamente para asegurar todo funcione de forma adecuada.

**Enpoint:**

```JS
app.get("/v1/explorers/stack/:value", (req, res) => {
    const stacks = req.params.value;
    const listOfExplorers = ExplorerController.filterByStack(stacks);
    res.status(200).json({listOfExplorers});
});
```

**Demo:**

![1](https://user-images.githubusercontent.com/83149636/165896994-2116f566-eb3a-45a3-b1ba-1fab4e2e0f09.gif)

