### PR TITLE
Pull Request new endpoint /v1/explorers/stack/:stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersWithStack(mission){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, mission);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -35,7 +35,7 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
 app.get("/v1/explorers/stack/:stack", (request, response) => {
     const explorers = ExplorerController.getExplorersWithStack(request.params.stack);
     response.json({stack: request.params.stack, total: explorers.length, explorers: explorers});
-})
+});
 
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,11 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const explorers = ExplorerController.getExplorersWithStack(request.params.stack);
+    response.json({stack: request.params.stack, total: explorers.length, explorers: explorers});
+})
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,16 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack) {
+        let explorersWithStack = [];
+        explorers.forEach(explorer => {
+            if (explorer.stacks.find(stackExplorer => stackExplorer === stack)) {
+                explorersWithStack.push(explorer);
+            }
+        });
+        return explorersWithStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controller/ExplorerController.test.js
+++ b/test/controller/ExplorerController.test.js
@@ -1,0 +1,9 @@
+const ExplorerController = require("../../lib/controllers/ExplorerController");
+
+describe("Tests para ExplorerController", () => {
+    test("Requerimiento PR: Regresa una lista de explorers con el stack solicitado", () => {
+        const explorersWithStack = ExplorerController.getExplorersWithStack("elm");
+        expect(explorersWithStack.length).toBe(12);
+    });
+
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -2,9 +2,31 @@ const ExplorerService = require("./../../lib/services/ExplorerService");
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
-        const explorers = [{mission: "node"}];
+        const explorers = [{ mission: "node" }];
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
+    });
+    test("Requerimiento PR: Regresa una lista de explorers con el stack solicitado", () => {
+        const explorers = [{
+            stacks: [
+                "javascript",
+                "elixir"
+            ]
+        },
+        {
+            stacks: [
+                "javascript",
+                "groovy",
+            ]
+        },
+        {
+            stacks: [
+                "elm",
+                "java"
+            ]
+        }];
+        const explorersWithStack = ExplorerService.filterByStack(explorers, "javascript");
+        expect(explorersWithStack.length).toBe(2);
     });
 
 });


### PR DESCRIPTION
What I did:
I use TDD methodology, so I wrote test and then refactoring the class.
First I found that all logic was written in the ExplorerService's then use those methods in ExplorerController that exposed to the server endpoints. In order to follow the same path I did next steps:

1.- Create a new test in ExplorerService.test.js where I define 3 explorers, 2 with stack of javascript and the other without the stack so this test should return 2 explorers. commit: [5787615](https://github.com/visualpartnership/fizzbuzz/pull/38/commits/57876154d5cc811d0f27a0be373784a376e0360d)

2.- Create new static method filterByStack in ExplorerService.js where it received 2 param (the explorers list and the stack) I define a let variable called explorersWithStack where I push all the explorers that had the stack received in the params. commit: [8def76c](https://github.com/visualpartnership/fizzbuzz/pull/38/commits/8def76c9abab8097a82cf9749816c51ab027da4a)

3.- Create a new test ExplorerController.test.js that should receive the stack only and should return the list of explorer with the stack required. commit: [53a0579](https://github.com/visualpartnership/fizzbuzz/pull/38/commits/53a0579d5b4de6b146ca0a4e5d823012238cf3b4)

4.- Create new static method getExplorersWithStack that receive the stack and use the method filterByStack created in ExplorerService. commit: [14f8a48](https://github.com/visualpartnership/fizzbuzz/pull/38/commits/14f8a489696f404d423c412570eff211a9d4ee98)

5.- Create a new endpoint /v1/explorers/stack/:stack that uses the getExplorersWithStack method. commit: [9958b0e](https://github.com/visualpartnership/fizzbuzz/pull/38/commits/9958b0ee72910d789a5a8272947ade589bbec138)

Finally, I run eslinter looking out for some error code syntax. commit: [d55915e](https://github.com/visualpartnership/fizzbuzz/pull/38/commits/d55915e9cc6b7f8edd0b2f335a0d01101d37cd89)