### PR TITLE
feat: add new API endpoint to return a list of explorers filter by stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,12 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorerByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        const explorersStack = ExplorerService.getExplorersByStack(explorers,stack);
+        return explorersStack;
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,11 +32,11 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
-app.get('/v1/explorers/stack/:stack', (req, res) => {
+app.get("/v1/explorers/stack/:stack", (req, res) => {
     const stack = req.params.stack;
     const explorersByStack = ExplorerController.getExplorerByStack(stack);
     res.status(200).json(explorersByStack);
-})
+});
 
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get('/v1/explorers/stack/:stack', (req, res) => {
+    const stack = req.params.stack;
+    const explorersByStack = ExplorerController.getExplorerByStack(stack);
+    res.status(200).json(explorersByStack);
+})
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers,stack){
+        const explorersStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersStack
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -18,7 +18,7 @@ class ExplorerService {
 
     static getExplorersByStack(explorers,stack){
         const explorersStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
-        return explorersStack
+        return explorersStack;
     }
 
 }

--- a/test/controller/ExplorerController.test.js
+++ b/test/controller/ExplorerController.test.js
@@ -1,12 +1,12 @@
-const ExplorerController = require('./../../lib/controllers/ExplorerController');
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
 
 describe("Test para ExplorerController", () => {
     test("getExplorerByStack function returns a list of explorers that contain into its property stacks the stack value passed", () => {
         //arrange and acts
-        const explorersJS = ExplorerController.getExplorerByStack('javascript');
+        const explorersJS = ExplorerController.getExplorerByStack("javascript");
         //asserts
         for(let i = 0; i < explorersJS.length; i++){
-            expect(explorersJS[i].stacks.includes('javascript')).toBeTruthy()
+            expect(explorersJS[i].stacks.includes("javascript")).toBeTruthy();
         }
     });
 });

--- a/test/controller/ExplorerController.test.js
+++ b/test/controller/ExplorerController.test.js
@@ -1,0 +1,12 @@
+const ExplorerController = require('./../../lib/controllers/ExplorerController');
+
+describe("Test para ExplorerController", () => {
+    test("getExplorerByStack function returns a list of explorers that contain into its property stacks the stack value passed", () => {
+        //arrange and acts
+        const explorersJS = ExplorerController.getExplorerByStack('javascript');
+        //asserts
+        for(let i = 0; i < explorersJS.length; i++){
+            expect(explorersJS[i].stacks.includes('javascript')).toBeTruthy()
+        }
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,5 +1,5 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
-const Reader = require('./../../lib/utils/reader');
+const Reader = require("./../../lib/utils/reader");
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
@@ -9,11 +9,11 @@ describe("Tests para ExplorerService", () => {
     });
     test("Requeriemto 2: filtrar los explorers por stack", () => {
         //arrange and acts
-        const explorers = Reader.readJsonFile('explorers.json');
-        const explorersJS = ExplorerService.getExplorersByStack(explorers, 'JavaScript')
+        const explorers = Reader.readJsonFile("explorers.json");
+        const explorersJS = ExplorerService.getExplorersByStack(explorers, "JavaScript");
         //asserts
         for(let i = 0; i < explorersJS.length; i++){
-            expect(explorersJS[i].stacks.includes('javascript')).toBeTruthy()
+            expect(explorersJS[i].stacks.includes("javascript")).toBeTruthy();
         }
     });
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,10 +1,20 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
+const Reader = require('./../../lib/utils/reader');
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
         const explorers = [{mission: "node"}];
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
+    });
+    test("Requeriemto 2: filtrar los explorers por stack", () => {
+        //arrange and acts
+        const explorers = Reader.readJsonFile('explorers.json');
+        const explorersJS = ExplorerService.getExplorersByStack(explorers, 'JavaScript')
+        //asserts
+        for(let i = 0; i < explorersJS.length; i++){
+            expect(explorersJS[i].stacks.includes('javascript')).toBeTruthy()
+        }
     });
 
 });


### PR DESCRIPTION
1. Added test to new static Function "getExplorersByStack" into ExplorersService.js
2. Added "getExplorersByStack" static Function and code to fulfill the test.
3. Ran test
4. Added test to new static function "getExplorerByStack" into ExplorerController.js
5. Added "getExplorerByStack" static function and code to accomplish the test.
6.  Ran test
7. Added new API endpoint to filter Explorers by stack using the ExplorerController new function "getExplorerByStack".
8. Ran `npm run linter` to look out errors.
9. Ran `npm run linter-fix` to fix errors.
10.  Pushed the repo to GitHub


