### PR TITLE
Requerimiento Añadido: Filtrar explorers por Stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorerByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack
+    const explorersInStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorersInStack);
+})
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,10 +33,10 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
 });
 
 app.get("/v1/explorers/stack/:stack", (request, response) => {
-    const stack = request.params.stack
+    const stack = request.params.stack;
     const explorersInStack = ExplorerController.getExplorersByStack(stack);
     response.json(explorersInStack);
-})
+});
 
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorerByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,8 @@
+const ExplorerContoller = require('./../../lib/controllers/ExplorerController')
+
+describe("Test para ExplorerController" ,() => {
+    test("Requerimiento 1: Obtener los explorers que cuenten con el stack solicitado", () => {
+        const explorersByStack = ExplorerContoller.getExplorersByStack("elixir")
+        expect(explorersByStack.length).not.toBe(0)
+    })
+})

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,8 +1,8 @@
-const ExplorerContoller = require('./../../lib/controllers/ExplorerController')
+const ExplorerContoller = require("./../../lib/controllers/ExplorerController");
 
 describe("Test para ExplorerController" ,() => {
     test("Requerimiento 1: Obtener los explorers que cuenten con el stack solicitado", () => {
-        const explorersByStack = ExplorerContoller.getExplorersByStack("elixir")
-        expect(explorersByStack.length).not.toBe(0)
-    })
-})
+        const explorersByStack = ExplorerContoller.getExplorersByStack("elixir");
+        expect(explorersByStack.length).not.toBe(0);
+    });
+});

--- a/test/explorers.test.json
+++ b/test/explorers.test.json
@@ -1,0 +1,160 @@
+[
+    {
+      "name": "Woopa1",
+      "githubUsername": "ajolonauta1",
+      "score": 1,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "reasonML",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa2",
+      "githubUsername": "ajolonauta2",
+      "score": 2,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "groovy",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa3",
+      "githubUsername": "ajolonauta3",
+      "score": 3,
+      "mission": "node",
+      "stacks": [
+        "elixir",
+        "groovy",
+        "reasonML"
+      ]
+    },
+    {
+      "name": "Woopa4",
+      "githubUsername": "ajolonauta4",
+      "mission": "node",
+      "score": 4,
+      "stacks": [
+        "javascript"
+      ]
+    },
+    {
+      "name": "Woopa5",
+      "githubUsername": "ajolonauta5",
+      "score": 5,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "elixir",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa6",
+      "githubUsername": "ajolonauta6",
+      "score": 6,
+      "mission": "java",
+      "stacks": [
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa7",
+      "githubUsername": "ajolonauta7",
+      "mission": "java",
+      "score": 7,
+      "stacks": [
+      ]
+    },
+    {
+      "name": "Woopa8",
+      "githubUsername": "ajolonauta8",
+      "score": 8,
+      "mission": "java",
+      "stacks": [
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa9",
+      "githubUsername": "ajolonauta9",
+      "score": 9,
+      "mission": "java",
+      "stacks": [
+        "javascript",
+        "elixir",
+        "groovy",
+        "reasonML",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa10",
+      "githubUsername": "ajolonauta10",
+      "score": 10,
+      "mission": "java",
+      "stacks": [
+        "javascript",
+        "elixir",
+        "groovy",
+        "reasonML",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa11",
+      "githubUsername": "ajolonauta11",
+      "score": 11,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "elixir",
+        "groovy",
+        "reasonML",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa12",
+      "githubUsername": "ajolonauta12",
+      "score": 12,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "elixir",
+        "groovy",
+        "reasonML",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa13",
+      "githubUsername": "ajolonauta13",
+      "score": 13,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "elixir",
+        "groovy",
+        "reasonML",
+        "elm"
+      ]
+    },
+    {
+      "name": "Woopa14",
+      "githubUsername": "ajolonauta14",
+      "score": 14,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "elixir",
+        "groovy",
+        "reasonML",
+        "elm"
+      ]
+    }
+    ]
+    

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,4 +1,5 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
+const Reader = require("./../../lib/utils/reader")
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
@@ -6,5 +7,9 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
-
+    test("Requerimiento 2: Obtener explorers filtrados por un stack", () => {
+        const explorers = Reader.readJsonFile('test/explorers.test.json')
+        const explorersWithStack = ExplorerService.getExplorerByStack(explorers, "elixir");
+        expect(explorersWithStack.length).not.toBe(0);
+    })
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,5 +1,5 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
-const Reader = require("./../../lib/utils/reader")
+const Reader = require("./../../lib/utils/reader");
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
@@ -8,8 +8,8 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
     test("Requerimiento 2: Obtener explorers filtrados por un stack", () => {
-        const explorers = Reader.readJsonFile('test/explorers.test.json')
+        const explorers = Reader.readJsonFile("test/explorers.test.json");
         const explorersWithStack = ExplorerService.getExplorerByStack(explorers, "elixir");
         expect(explorersWithStack.length).not.toBe(0);
-    })
+    });
 });


### PR DESCRIPTION
# Descripción.
Se agregarón las pruebas de ExplorerController.test.js para poder comprobar la conexión exitosa con el servicio así como la prueba de ExplorerService.test.js para verificar el correcto funcionamiento del método que filtra por stack.

## ExplorerService - Método para filtrar por stack
```javascript
static getExplorerByStack(explorers, stack){
        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
        return explorersByStack;
}
```

# La lógica que usé de manera gráfica:
```mermaid
graph TD;
    Todos-los-explorers-->Reader
    Método-Filtro-->Conexión-explorers-filtrado
    Reader-->Conexión-explorers-filtrado
   Conexión-explorers-filtrado-->Explorer-Filtrado
```
# El endpoint para filtrar por stack.
| Endpoint | Description |
|---|---|
| `localhost:3000/v1/explorers/stack/:stack` | Filtrado por stack |

# Demo
![FilterByStack](https://user-images.githubusercontent.com/63875704/166081275-6540d4a1-4b84-48b8-bb15-d7f7dd0774b7.gif)

