### PR TITLE
Filtro de explorers por stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static filterByStack(stack) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (req, res) => {
+    const stack = req.params.stack;
+    const result = ExplorerController.filterByStack(stack);
+    res.json(result);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -5,6 +5,11 @@ class ExplorerService {
         return explorersByMission;
     }
 
+    static filterByStack(explorers, tec) {
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.some((stack) => stack === tec));
+        return explorersByStack
+    }
+
     static getAmountOfExplorersByMission(explorers, mission){
         const explorersByMission = ExplorerService.filterByMission(explorers, mission);
         return explorersByMission.length;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,12 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Obtener explorers por stack", () => {
+        const explorers = [{name: "Woopa", stacks: ["javascript", "elixir", "elm"]}, {name: "Woopa2", stacks: ["elixir", "elm", "groovy"]}];
+        const stack = "javascript";
+        const result = ExplorerService.filterByStack(explorers, stack);
+        expect(result[0].stacks.some((stack) => stack === "javascript")).toBe(true);
+        expect(result.length).toBe(1);
+    })
+
 });


### PR DESCRIPTION
Lo primero fue crear un nuevo método en la clase **ExplorerService**, el cual toma como parámetros el JSON de los explorers y la tecnología o stack a buscar para filtrar. 

![image](https://user-images.githubusercontent.com/77386102/166093237-d1e13ecd-b464-4d73-b559-4e90526ca312.png)

Lo siguiente fue agregar la prueba para estar seguros que el nuevo método funcionara bien.

![image](https://user-images.githubusercontent.com/77386102/166093308-cef9c082-73a3-47f7-8265-351469592c8b.png)

 En el **ExplorerController** agregué el método que se usaría en **server**, este método solo acepta como parámetro el stack ya que, el parámetro explorers le va a ser dado aquí al método de **ExplorerService**.
 
![image](https://user-images.githubusercontent.com/77386102/166093412-8bbeae0c-5dad-4e1f-8a71-19f2a8d65304.png)

Por ultimo, cree un endpoint que recibe un stack que es almacenado en una constante, para después pasarlo como parámetro al método `filterByStack`, y enviar como respuesta a los explorers con el stack solicitado.

![image](https://user-images.githubusercontent.com/77386102/166093566-c5ab79c6-7f94-4b3d-87a7-d99e85881d84.png)
