### PR TITLE
Añadiendo endpoint para consulta de explorers filtrados por stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -24,7 +24,7 @@ class ExplorerController{
 
     static filterByStack(stack){
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByStack(explorers, stack)
+        return ExplorerService.filterByStack(explorers, stack);
     }
 }
 

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static filterByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack)
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,11 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/stack/:stack", (request, response) => {
+    const filteredStudents = ExplorerController.filterByStack(request.params.stack)
+    response.json(filteredStudents)
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,8 +33,8 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
 });
 
 app.get("/v1/stack/:stack", (request, response) => {
-    const filteredStudents = ExplorerController.filterByStack(request.params.stack)
-    response.json(filteredStudents)
+    const filteredStudents = ExplorerController.filterByStack(request.params.stack);
+    response.json(filteredStudents);
 });
 
 app.listen(port, () => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,7 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
-app.get("/v1/stack/:stack", (request, response) => {
+app.get("/v1/explorers/stack/:stack", (request, response) => {
     const filteredStudents = ExplorerController.filterByStack(request.params.stack);
     response.json(filteredStudents);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack) {
+        return explorers.filter((explorer) => explorer.stacks.includes(stack))
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -17,7 +17,7 @@ class ExplorerService {
     }
 
     static filterByStack(explorers, stack) {
-        return explorers.filter((explorer) => explorer.stacks.includes(stack))
+        return explorers.filter((explorer) => explorer.stacks.includes(stack));
     }
 
 }

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,25 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Regresar todos los explorers que tengan en stack el valor recibido en la url", () => {
+        const explorers = [{
+            "stacks": [
+              "javascript",
+              "reasonML",
+              "elm"
+            ]
+          },
+          {
+            "stacks": [
+              "javascript",
+              "groovy",
+              "elm"
+            ]
+          }]
+        let explorersWithStack = ExplorerService.filterByStack(explorers, "javascript")
+        expect(explorersWithStack.length).toBe(2)
+        explorersWithStack = ExplorerService.filterByStack(explorers, "reasonML")
+        expect(explorersWithStack.length).toBe(1)
+    })
+
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -10,22 +10,22 @@ describe("Tests para ExplorerService", () => {
     test("Requerimiento 2: Regresar todos los explorers que tengan en stack el valor recibido en la url", () => {
         const explorers = [{
             "stacks": [
-              "javascript",
-              "reasonML",
-              "elm"
+                "javascript",
+                "reasonML",
+                "elm"
             ]
-          },
-          {
+        },
+        {
             "stacks": [
-              "javascript",
-              "groovy",
-              "elm"
+                "javascript",
+                "groovy",
+                "elm"
             ]
-          }]
-        let explorersWithStack = ExplorerService.filterByStack(explorers, "javascript")
-        expect(explorersWithStack.length).toBe(2)
-        explorersWithStack = ExplorerService.filterByStack(explorers, "reasonML")
-        expect(explorersWithStack.length).toBe(1)
-    })
+        }];
+        let explorersWithStack = ExplorerService.filterByStack(explorers, "javascript");
+        expect(explorersWithStack.length).toBe(2);
+        explorersWithStack = ExplorerService.filterByStack(explorers, "reasonML");
+        expect(explorersWithStack.length).toBe(1);
+    });
 
 });


### PR DESCRIPTION
Hola Carlo! Buenas tardes, espero te encuentres muy bien, y gracias por todo el esfuerzo que pones en el programa para enseñarnos tantas cosas.

# Endpoint para consultar alumnos filtrados por stack
## Uso
Endpoint: `"localhost:3000/v1/explorers/stack/:stack"`

`:stack` deberás reemplazarlo por el nombre de la tecnología por la que deseas filtrar a los explorers

Por ejemplo, si introduces la url: `localhost:3000/v1/explorers/stack/elixir`, recibirás como respuesta:
```json
[{"name":"Woopa3","githubUsername":"ajolonauta3","score":3,"mission":"node","stacks":["elixir","groovy","reasonML"]},{"name":"Woopa5","githubUsername":"ajolonauta5","score":5,"mission":"node","stacks":["javascript","elixir","elm"]},{"name":"Woopa9","githubUsername":"ajolonauta9","score":9,"mission":"java","stacks":["javascript","elixir","groovy","reasonML","elm"]},{"name":"Woopa10","githubUsername":"ajolonauta10","score":10,"mission":"java","stacks":["javascript","elixir","groovy","reasonML","elm"]},{"name":"Woopa11","githubUsername":"ajolonauta11","score":11,"mission":"node","stacks":["javascript","elixir","groovy","reasonML","elm"]},{"name":"Woopa12","githubUsername":"ajolonauta12","score":12,"mission":"node","stacks":["javascript","elixir","groovy","reasonML","elm"]},{"name":"Woopa13","githubUsername":"ajolonauta13","score":13,"mission":"node","stacks":["javascript","elixir","groovy","reasonML","elm"]},{"name":"Woopa14","githubUsername":"ajolonauta14","score":14,"mission":"node","stacks":["javascript","elixir","groovy","reasonML","elm"]},{"name":"Woopa15","githubUsername":"ajolonauta15","score":15,"mission":"node","stacks":["javascript","elixir","groovy","reasonML","elm"]}]
```
correspondiente a la lista de explorers que cuentan con "elixir" en su stack.

## Diseño
Lo añadido para resolver la solución fue lo siguiente: 
- Método` filterByStack(explorers, stack)` para la clase `ExplorerService` 
Este método es el encargado de filtrar por el stack que se le pasa como argumento
- Método` filterByStack(stack)` para la clase `ExplorerController`
Se encarga de llamar al método `ExplorerService.filterByStack(stack)` con un único argumento `stack`
- Endpoint `"localhost:3000/v1/explorers/stack/:stack"`
Aquí se levanta el endpoint citado y se llama al método `ExplorerController.filterByStack(stack)` al que se le pasa de argumento lo recibido en la sección `:stack` de la url

Todo lo anterior se agregó con sus respectivas pruebas unitarias, que se pueden consultar en los commits.
