### PR TITLE
Contribution - Add explorers filter by stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -1,6 +1,6 @@
 const ExplorerService = require("../services/ExplorerService");
 const FizzbuzzService = require("../services/FizzbuzzService");
-const Reader = require("../utils/reader");
+const Reader = require("../utils/Reader");
 
 class ExplorerController{
     static getExplorersByMission(mission){
@@ -20,6 +20,11 @@ class ExplorerController{
     static getExplorersAmonutByMission(mission){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
+    }
+
+    static getExplorersByStack(stack) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
     }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,14 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+// Contribution
+app.get("/v1/explorers/stack/:stack", (req, res) => {
+    const stack = req.params.stack;
+    const explorersByStack = ExplorerController.getExplorersByStack(stack);
+
+    res.json(explorersByStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,9 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack){
+        return explorers.filter((explorer) => explorer.stacks.some((item) => item === stack));
+    }
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,10 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+
+describe("Test Suits for ExplorerController.js", () => {
+    test("Contribución Open Source: Regresar lista de explorers filtrados por stack", () => {
+        const results = ExplorerController.getExplorersByStack("javascript");
+        console.log(results);
+
+        expect(results).not.toBe(undefined);
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,10 +1,18 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
+const Reader = require("./../../lib/utils/Reader");
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
         const explorers = [{mission: "node"}];
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
+    });
+
+    test("Contribución Open Source: Regresar lista de explorers filtrados por stack", () => {
+        const explorers = Reader.readJsonFile("explorers.json");
+        const results = ExplorerService.getExplorersByStack(explorers, "javascript");
+
+        expect(results).not.toBe(undefined);
     });
 
 });


### PR DESCRIPTION
**Process**

1. Create new function `getExplorersByStack(explorers, stack)` in ExplorerService.js.
2. Create new function `static getExplorersByStack(stack)` in ExplorerController.
3. Create new endpoint `app.get("/v1/explorers/stack/:stack", (req, res) => {})` in server.js.