### PR TITLE
Agregando endpoint que regrese toda la lista de explorers filtrados por un stack.

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersFilterByStack(stack) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersFilterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersFilterStack = ExplorerController.getExplorersFilterByStack(stack);
+    response.json(explorersFilterStack);
+})
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersFilterByStack(explorers, stack) {
+        const result = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return result;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -4,7 +4,7 @@ describe("Pruebas de unidad para la clase ExplorerController", () => {
 
     test("Validar funcionalidad getExplorersFilterByStack", () => {        
         const result = ExplorerController.getExplorersFilterByStack("javascript");
-        expect(result.length).toBe(10);
+        expect(result.length).toBe(11);
         expect(result).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,16 @@
+const ExplorerController = require("../../lib/controllers/ExplorerController");
+
+describe("Pruebas de unidad para la clase ExplorerController", () => {
+
+    test("Validar funcionalidad getExplorersFilterByStack", () => {        
+        const result = ExplorerController.getExplorersFilterByStack("javascript");
+        expect(result.length).toBe(11);
+        expect(result).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    stacks: (expect.arrayContaining(["javascript"]))
+                })
+            ])
+        );
+    });
+});

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -4,7 +4,7 @@ describe("Pruebas de unidad para la clase ExplorerController", () => {
 
     test("Validar funcionalidad getExplorersFilterByStack", () => {        
         const result = ExplorerController.getExplorersFilterByStack("javascript");
-        expect(result.length).toBe(11);
+        expect(result.length).toBe(10);
         expect(result).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -32,7 +32,7 @@ describe("Tests para ExplorerService", () => {
               ]
             }];
         const result = ExplorerService.getExplorersFilterByStack(explorers, "javascript");
-        expect(result.length).toBe(11);
+        expect(result.length).toBe(2);
         expect(result).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -32,7 +32,7 @@ describe("Tests para ExplorerService", () => {
               ]
             }];
         const result = ExplorerService.getExplorersFilterByStack(explorers, "javascript");
-        expect(result.length).toBe(1);
+        expect(result.length).toBe(2);
         expect(result).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -32,7 +32,7 @@ describe("Tests para ExplorerService", () => {
               ]
             }];
         const result = ExplorerService.getExplorersFilterByStack(explorers, "javascript");
-        expect(result.length).toBe(2);
+        expect(result.length).toBe(1);
         expect(result).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,38 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Obtener la lista de explorer que incluyen en su stack el valor enviado", () => {
+        const explorers = [
+            {
+              "name": "Woopa1",
+              "githubUsername": "ajolonauta1",
+              "score": 1,
+              "mission": "node",
+              "stacks": [
+                "javascript",
+                "reasonML",
+                "elm"
+              ]
+            },
+            {
+              "name": "Woopa2",
+              "githubUsername": "ajolonauta2",
+              "score": 2,
+              "mission": "node",
+              "stacks": [
+                "javascript",
+                "groovy",
+                "elm"
+              ]
+            }];
+        const result = ExplorerService.getExplorersFilterByStack(explorers, "javascript");
+        expect(result.length).toBe(11);
+        expect(result).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    stacks: (expect.arrayContaining(["javascript"]))
+                })
+            ])
+        );
+    });
 });


### PR DESCRIPTION
Hola. 

Se agrega endpoint el cual dependiendo del valor `stack` recibido da como respuesta la lista de explorers que contenga ese stack en su atributo `stacks`.'

Para cada método se creo su respectiva prueba de unidad. 

- Se creo el método `getExplorersFilterByStack` en la clase `ExplorerService` el cual recibe como parámetros la lista de explorers y el valor del stack que queremos filtrar, devuelve una lista con los explorers que contengan el recibido en su stacks. 

~~~
static getExplorersFilterByStack(explorers, stack) {
        const result = explorers.filter((explorer) => explorer.stacks.includes(stack));
        return result;
    }
~~~

- También se creo el método `getExplorersFilterByStack ` en la clase `ExplorerController` el cual recibe como parametro el valor del stack que queremos filtrar. 

~~~
static getExplorersFilterByStack(stack) {
        const explorers = Reader.readJsonFile("explorers.json");
        return ExplorerService.getExplorersFilterByStack(explorers, stack);
    }
~~~

- Finalmente se agrego el endpoint en el server, al cual se puede acceder mediante la url `localhost:3000/v1/explorers/stack/:stack`

~~~
app.get("/v1/explorers/stack/:stack", (request, response) => {
    const stack = request.params.stack;
    const explorersFilterStack = ExplorerController.getExplorersFilterByStack(stack);
    response.json(explorersFilterStack);
})
~~~

- Prueba de endpoint 
![endpoint](https://user-images.githubusercontent.com/6106637/166164781-5e82b62b-7c6d-4b2c-9525-504a5428d663.gif)

Se verifico formato de codigo con Linter. 
Se verificaron las pruebas de unidad con la dependencia Jest. 

Saludos. 




