### PR TITLE
Se crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests in my project every push on GitHub
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Run Tests in my project every push on GitHub
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+package-lock.json
+package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = parseInt(request.params.stack);
+    const explorersInStack = ExplorerController.applyFizzbuzz(score);
+    response.json({score: score, trick: fizzbuzzTrick});
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,9 +33,9 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
 });
 
 app.get("/v1/explorers/stack/:stack", (request, response) => {
-    const stack = parseInt(request.params.stack);
-    const explorersInStack = ExplorerController.applyFizzbuzz(score);
-    response.json({score: score, trick: fizzbuzzTrick});
+    const stack = request.params.stack;
+    const explorersInStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorersInStack);
 });
 
 app.listen(port, () => {

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/readme.md
+++ b/readme.md
@@ -1,16 +1,41 @@
-# Linter
+# Solicitud
 
-1. Instalar dependencia:
+Para esta modificacion se solicita:
 
-> npm install eslint --save-dev
+Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.
 
-2. Modificar package.json, agregar debajo de test
+  - Ejemplo de url: `localhost:3000/v1/explorers/stack/javascript`.
+  - Response: Todos los explorers que tengan en `stack` el valor recibido en la url: `javascript`. (este valor debe ser dinámico)
 
-> "linter": "node ./node_modules/eslint/bin/eslint.js"
+# Proceso
 
-3. Crear configuración en archivo .eslintrc (si se versiona)
+Se separa en 2 preparar el ambiente de desarrollo para ello se siguen los siguientes pasos:
+  - Se agrega la dependencia de linter con el comando > npm install eslint --save-dev .
+  - Se agrega la dependencia para test (jest) con el comando > npm install --save-dev jest .
+  - Se agrega la dependencia de express para el server con el comando > npm install express --save .
 
-> npm init @eslint/config
+El siguiente grafico representa el esquema actual de la solucion:
+```mermaid
+graph TD;
+    Reader-->ExplorerService;
+    FizzbuzzService;
+    ExplorerService-->ExplorerController
+    FizzbuzzService-->ExplorerController
+    ExplorerController-->Server
+```
 
-Rules: https://eslint.org/docs/rules/
-Airbnb Code Style: https://github.com/airbnb/javascript
+Una vez que se preparo el ambiente para la parte de desarrollo se hace lo siguiente:
+  - Se agregan todas las pruebas unitarias para las clases existentes.
+  - Tuve que hacer un cambio en el test.yml, ya que por alguna razón no corran las GitHub actions.
+  - Se agrega el metodo getExplorersByStack en ExplorerController y ExplorerService con sus pruebas.
+  - Se agrega el endpoint en server.js
+
+# Resultado
+
+Una vez hecho lo anterior, corrido las pruebas y haber corrido linter el resultado es el siguiente:
+
+![image](https://user-images.githubusercontent.com/99153503/166164720-0b6419e7-487d-4bb2-969d-5dd8ed5bc371.gif)
+
+# Pendientes
+
+Por alguna razon no me reconocio el .gitignore que agregara el package.json por lo que en mi git aun tengo el archivo como un cambio.

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -45,4 +45,14 @@ describe("Test para ExplorerController", () => {
         const explorer15Validate = ExplorerController.applyFizzbuzz(15);
         expect(explorer15Validate).toBe("FIZZBUZZ");
     });
+
+    test("prueba 10: Obtener la cantidad de explorers con el stack java", () => {
+        const explorersInJava = ExplorerController.getExplorersByStack("java");
+        expect(explorersInJava.length).toBe(0);
+    });
+
+    test("prueba 11: Obtener la cantidad de explorers con el stack javascript", () => {
+        const explorersInJava = ExplorerController.getExplorersByStack("javascript");
+        expect(explorersInJava.length).toBe(11);
+    });
 });

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,48 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+
+describe("Test para ExplorerController", () => {
+    test("Requerimiento 1: Calcular todos los explorers en la mision node", () => {
+        const explorersInNode = ExplorerController.getExplorersByMission("node");
+        expect(explorersInNode.length).toBe(10);
+    });
+
+    test("Requerimiento 2: Calcular todos los explorers en la mision java", () => {
+        const explorersInJava = ExplorerController.getExplorersByMission("java");
+        expect(explorersInJava.length).toBe(5);
+    });
+
+    test("Requerimiento 3: Obtener los usuarios de los explorers de una mision especifica", () => {
+        const usersInNode = ExplorerController.getExplorersUsernamesByMission("node");
+        expect(usersInNode).toStrictEqual(["ajolonauta1", "ajolonauta2", "ajolonauta3", "ajolonauta4", "ajolonauta5", "ajolonauta11", "ajolonauta12", "ajolonauta13", "ajolonauta14", "ajolonauta15"]);
+    });
+
+    test("Requerimiento 4: Obtener la cantidad de explorers en la mision node", () => {
+        const explorersInNode = ExplorerController.getExplorersAmonutByMission("node");
+        expect(explorersInNode).toBe(10);
+    });
+
+    test("Requerimiento 5: Obtener la cantidad de explorers en la mision java", () => {
+        const explorersInJava = ExplorerController.getExplorersAmonutByMission("java");
+        expect(explorersInJava).toBe(5);
+    });
+
+    test("Prueba 6: se usa score: 1", () => {
+        const explorer1Validate = ExplorerController.applyFizzbuzz(1);
+        expect(explorer1Validate).toBe(1);
+    });
+
+    test("Prueba 7: se usa score: 3", () => {
+        const explorer3Validate = ExplorerController.applyFizzbuzz(3);
+        expect(explorer3Validate).toBe("FIZZ");
+    });
+
+    test("Prueba 8: se usa score: 5", () => {
+        const explorer5Validate = ExplorerController.applyFizzbuzz(5);
+        expect(explorer5Validate).toBe("BUZZ");
+    });
+
+    test("Prueba 9: se usa score: 15", () => {
+        const explorer15Validate = ExplorerController.applyFizzbuzz(15);
+        expect(explorer15Validate).toBe("FIZZBUZZ");
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -30,4 +30,16 @@ describe("Tests para ExplorerService", () => {
         const explorersInJava = ExplorerService.getAmountOfExplorersByMission(explorers, "java");
         expect(explorersInJava).toBe(1);
     });
+
+    test("Requerimiento 6: Obtener la cantidad de explorers con el stack java", () => {
+        const explorers = [{githubUsername: "ajolonauta1", mission: "java", stacks: ["java", "reasonML", "elm"]}];
+        const explorersInJava = ExplorerService.getExplorersByStack(explorers, "java");
+        expect(explorersInJava.length).toBe(1);
+    });
+
+    test("Requerimiento 7: Obtener los explorers con el stack java", () => {
+        const explorers = [{githubUsername: "ajolonauta1", mission: "java", stacks: ["java", "reasonML", "elm"]}];
+        const explorersInJava = ExplorerService.getExplorersByStack(explorers, "java");
+        expect(explorersInJava).toStrictEqual([{githubUsername: "ajolonauta1", mission: "java", stacks: ["java", "reasonML", "elm"]}]);
+    });
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,27 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Calcular todos los explorers en la mision java", () => {
+        const explorers = [{mission: "java"}];
+        const explorersInJava = ExplorerService.filterByMission(explorers, "java");
+        expect(explorersInJava.length).toBe(1);
+    });
+
+    test("Requerimiento 3: Obtener los usuarios de los explorers de una mision especifica", () => {
+        const explorers = [{githubUsername: "ajolonauta1", mission: "node"}];
+        const usersInNode = ExplorerService.getExplorersUsernamesByMission(explorers, "node");
+        expect(usersInNode).toStrictEqual(["ajolonauta1"]);
+    });
+
+    test("Requerimiento 4: Obtener la cantidad de explorers en la mision node", () => {
+        const explorers = [{githubUsername: "ajolonauta1", mission: "node"}];
+        const explorersInNode = ExplorerService.getAmountOfExplorersByMission(explorers, "node");
+        expect(explorersInNode).toBe(1);
+    });
+
+    test("Requerimiento 5: Obtener la cantidad de explorers en la mision java", () => {
+        const explorers = [{githubUsername: "ajolonauta1", mission: "java"}];
+        const explorersInJava = ExplorerService.getAmountOfExplorersByMission(explorers, "java");
+        expect(explorersInJava).toBe(1);
+    });
 });

--- a/test/services/FizzbuzzService.test.js
+++ b/test/services/FizzbuzzService.test.js
@@ -1,0 +1,47 @@
+const FizzbuzzService = require("./../../lib/services/FizzbuzzService");
+
+describe("Test para ExplorerService", () => {
+    test("Prueba 1: se usa score: 1", () => {
+        const explorer1 = {name: "Explorer1", score: 1};
+        const explorer1Validate = FizzbuzzService.applyValidationInExplorer(explorer1);
+        expect(explorer1Validate).toStrictEqual({name: "Explorer1", score: 1, trick: 1});
+    });
+
+    test("Prueba 2: se usa score: 3", () => {
+        const explorer3 = {name: "Explorer3", score: 3};
+        const explorer3Validate = FizzbuzzService.applyValidationInExplorer(explorer3);
+        expect(explorer3Validate).toStrictEqual({name: "Explorer3", score: 3, trick: "FIZZ"});
+    });
+
+    test("Prueba 3: se usa score: 5", () => {
+        const explorer5 = {name: "Explorer5", score: 5};
+        const explorer5Validate = FizzbuzzService.applyValidationInExplorer(explorer5);
+        expect(explorer5Validate).toStrictEqual({name: "Explorer5", score: 5, trick: "BUZZ"});
+    });
+
+    test("Prueba 4: se usa score: 15", () => {
+        const explorer15 = {name: "Explorer15", score: 15};
+        const explorer15Validate = FizzbuzzService.applyValidationInExplorer(explorer15);
+        expect(explorer15Validate).toStrictEqual({name: "Explorer15", score: 15, trick: "FIZZBUZZ"});
+    });
+
+    test("Prueba 5: se usa score: 1", () => {
+        const explorer1Validate = FizzbuzzService.applyValidationInNumber(1);
+        expect(explorer1Validate).toBe(1);
+    });
+
+    test("Prueba 5: se usa score: 3", () => {
+        const explorer3Validate = FizzbuzzService.applyValidationInNumber(3);
+        expect(explorer3Validate).toBe("FIZZ");
+    });
+
+    test("Prueba 5: se usa score: 5", () => {
+        const explorer5Validate = FizzbuzzService.applyValidationInNumber(5);
+        expect(explorer5Validate).toBe("BUZZ");
+    });
+
+    test("Prueba 5: se usa score: 15", () => {
+        const explorer15Validate = FizzbuzzService.applyValidationInNumber(15);
+        expect(explorer15Validate).toBe("FIZZBUZZ");
+    });
+});

--- a/test/utils/reader.test.js
+++ b/test/utils/reader.test.js
@@ -1,0 +1,8 @@
+const Reader = require("./../../lib/utils/reader");
+
+describe("Test para ExplorerService", () => {
+    test("Requerimiento 1: Calcular todos los explorers en una mision", () => {
+        const explorersRead = Reader.readJsonFile("explorers.json");
+        expect(explorersRead.length).toBe(15);
+    });
+});


### PR DESCRIPTION
Mi proceso se separa en 2, preparar el ambiente de desarrollo, para ello se siguen los siguientes pasos:
  - Se agrega la dependencia de linter con el comando > npm install eslint --save-dev .
  - Se agrega la dependencia para test (jest) con el comando > npm install --save-dev jest .
  - Se agrega la dependencia de express para el server con el comando > npm install express --save .

Una vez que se preparó el ambiente para la parte de desarrollo se hace lo siguiente:
  - Se agregan todas las pruebas unitarias para las clases existentes.
  - Tuve que hacer un cambio en el test.yml, ya que por alguna razón no corran las GitHub actions.
  - Se agrega el metodo getExplorersByStack en ExplorerController y ExplorerService con sus pruebas.
  - Se agrega el endpoint en server.js

Hay mas cambios de los que nos dijo que deberia, pero agregue todas las pruebas que crei pertinentes, tambien estan los cambios de mi readme asi como los del gitignore aunque no me funcionaron.