### PR TITLE
Integración EndPoint para obtener explorers por stack

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,4 +20,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Run install dependecies
+      run: npm install
+    - name: Run server
       run: npm run server 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Run install dependecies
       run: npm install
     - name: Run server
-      run: npm run server 
+      run: npm run server &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,3 +9,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run Jest
       uses: stefanoeb/jest-action@1.0.3
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Run install dependecies
+      run: npm run server 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Run Tests in my project every push on GitHub
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(mission){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, mission);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -22,9 +22,9 @@ class ExplorerController{
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
 
-    static getExplorersByStack(mission){
+    static getExplorersByStack(stack_name){
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByStack(explorers, mission);
+        return ExplorerService.filterByStack(explorers, stack_name);
     }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,7 +38,13 @@ app.get("/v1/explorers/stack/:stack_name", (request, response) => {
     response.json({stack: stack_name, explorers: explorersByStack});
 });
 
+console.log(app.address());
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });
 
+setTimeout((function(){
+  app.close()
+  console.log(app.address()); // null
+}), 3000);

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,13 +38,6 @@ app.get("/v1/explorers/stack/:stack_name", (request, response) => {
     response.json({stack: stack_name, explorers: explorersByStack});
 });
 
-console.log(app.address());
-
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });
-
-setTimeout((function(){
-  app.close()
-  console.log(app.address()); // null
-}), 3000);

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack_name", (request, response) => {
+    const stack_name = request.params.stack_name;
+    const explorersByStack = ExplorerController.getExplorersByStack(stack_name);
+    response.json({stack: stack_name, explorers: explorersByStack});
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -20,7 +20,7 @@ class ExplorerService {
         if([null,undefined].includes(explorers) || [null,undefined].includes(stack_name)){
             return [];
         }
-        return explorers.filter((each_explorer) => each_explorer.stacks.includes(stack_name))
+        return explorers.filter((each_explorer) => each_explorer.stacks.includes(stack_name));
     }
 }
 

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,12 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, mission){
+        if([null,undefined].includes(explorers) || [null,undefined].includes(mission)){
+            return [];
+        }
+        return explorers.filter((each_explorer) => each_explorer.stacks.includes(mission))
+    }
 }
 
 module.exports = ExplorerService;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,11 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
-    static filterByStack(explorers, mission){
-        if([null,undefined].includes(explorers) || [null,undefined].includes(mission)){
+    static filterByStack(explorers, stack_name){
+        if([null,undefined].includes(explorers) || [null,undefined].includes(stack_name)){
             return [];
         }
-        return explorers.filter((each_explorer) => each_explorer.stacks.includes(mission))
+        return explorers.filter((each_explorer) => each_explorer.stacks.includes(stack_name))
     }
 }
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -9,8 +9,8 @@ describe("Tests para ExplorerService", () => {
 
     test('Requerimiento 2: Obtener los explorers que se encuentres en una misión en especifica', () => {
 
-        let explorers = ExplorerService.filterByStack(null, null);
-        expect(explorers).toEqual([]);
+        let result = ExplorerService.filterByStack(null, null);
+        expect(result).toEqual([]);
 
         result = ExplorerService.filterByStack();
         expect(result).toEqual([]);
@@ -38,7 +38,7 @@ describe("Tests para ExplorerService", () => {
         expect(result[0].stacks).toContain('javascript');
 
         result = ExplorerService.filterByStack(explorers, 'groovy');
-        expect(result.length).toBe(2);
+        expect(result.length).toBe(1);
         expect(result[0].stacks).toContain('groovy');
 
     })

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,39 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test('Requerimiento 2: Obtener los explorers que se encuentres en una misión en especifica', () => {
+
+        let explorers = ExplorerService.filterByStack(null, null);
+        expect(explorers).toEqual([]);
+
+        result = ExplorerService.filterByStack();
+        expect(result).toEqual([]);
+
+        const explorers = [
+            {
+                name: 'Woopa1',
+                mission: 'node',
+                stacks:['javascript','reasonML']
+            },
+            {
+                name: 'Woopa2',
+                mission: 'node',
+                stacks:['reasonML', 'elm','groovy']
+            },
+            {
+                name: 'Woopa3',
+                mission: 'node',
+                stacks:['elm', 'javascript']
+            }
+        ];
+
+        result = ExplorerService.filterByStack(explorers, 'javascript');
+        expect(result.length).toBe(2);
+        expect(result[0].stacks).toContain('javascript');
+
+        result = ExplorerService.filterByStack(explorers, 'groovy');
+        expect(result.length).toBe(2);
+        expect(result[0].stacks).toContain('groovy');
+
+    })
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,7 +7,7 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
-    test('Requerimiento 2: Obtener los explorers que se encuentres en una misión en especifica', () => {
+    test("Requerimiento 2: Obtener los explorers que se encuentres en una misión en especifica", () => {
 
         let result = ExplorerService.filterByStack(null, null);
         expect(result).toEqual([]);
@@ -17,29 +17,29 @@ describe("Tests para ExplorerService", () => {
 
         const explorers = [
             {
-                name: 'Woopa1',
-                mission: 'node',
-                stacks:['javascript','reasonML']
+                name: "Woopa1",
+                mission: "node",
+                stacks:["javascript","reasonML"]
             },
             {
-                name: 'Woopa2',
-                mission: 'node',
-                stacks:['reasonML', 'elm','groovy']
+                name: "Woopa2",
+                mission: "node",
+                stacks:["reasonML", "elm","groovy"]
             },
             {
-                name: 'Woopa3',
-                mission: 'node',
-                stacks:['elm', 'javascript']
+                name: "Woopa3",
+                mission: "node",
+                stacks:["elm", "javascript"]
             }
         ];
 
-        result = ExplorerService.filterByStack(explorers, 'javascript');
+        result = ExplorerService.filterByStack(explorers, "javascript");
         expect(result.length).toBe(2);
-        expect(result[0].stacks).toContain('javascript');
+        expect(result[0].stacks).toContain("javascript");
 
-        result = ExplorerService.filterByStack(explorers, 'groovy');
+        result = ExplorerService.filterByStack(explorers, "groovy");
         expect(result.length).toBe(1);
-        expect(result[0].stacks).toContain('groovy');
+        expect(result[0].stacks).toContain("groovy");
 
-    })
+    });
 });


### PR DESCRIPTION
Estos fueron los pasos que realice para Agregar el EndPoint para obtener los explorers que este en un stack en especifico

1. Desarrollar prueba unitaria para un método llamado filterByStack.
 - Prueba1: Pasar parametros null y undefined.
   * Se espera que regrese 0
 - Prueba1: Pasar parametros esperados(javascript,reasonML, etc..).
   * Se espera que regrese 1 en un entorno controlado.

2. Crear en la clase ExplorerService metodo filterByStack para solucionar Paso1.

3. Integrar un nuevo método getExplorersByStack en ExplorerController(utilizar método filterByStack de ExplorerService).

4. Implementar endpoint en script server.js utilizando el método getExplorersByStack de ExplorerController.

5. Aplicar pruebas del servidor corriendo.

6. Refactorizar código(si hubo fallas).