### PR TITLE
Added requirement: Filter by stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,6 +26,12 @@ app.get("/v1/explorers/usernames/:mission", (request, response) => {
     response.json({mission: request.params.mission, explorers: explorersUsernames});
 });
 
+app.get("/v1/explorers/stack/:tech", (request, response) => {
+    const tech = request.params.tech;
+    const result = ExplorerController.getExplorersByStack(tech);
+    response.json(result);
+});
+
 app.get("/v1/fizzbuzz/:score", (request, response) => {
     const score = parseInt(request.params.score);
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack){
+        return explorers.filter(({stacks}) => stacks.includes(stack));
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
     "linter": "node ./node_modules/eslint/bin/eslint.js",
     "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
     "server": "node ./lib/server.js"

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,4 +1,5 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
+const Reader = require("../../lib/utils/reader.js");
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
@@ -6,5 +7,9 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
-
+    test("2) Filter by stack", () => {
+        const explorers = Reader.readJsonFile("explorers.json");
+        const filtered = ExplorerService.filterByStack(explorers, "javascript");
+        expect(filtered).not.toBeUndefined();
+    });
 });


### PR DESCRIPTION
- **Method `filterByStack` in class ExplorerService:** This method returns an array containing the stack specified in params. I used a filter method and object destructuring. Also I added a test for this method.

- **Method `getExplorersByStack` in class ExplorerController:** This method was created to communicate with the server and need the class `filterByStack` to work.

- **Endpoint `/v1/explorers/stack/:tech` in server:** This endpoint returns the explorers that containing the technology indicated in the query params.
