### PR TITLE
Agregando parte de búsqueda por Stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,10 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+    static GetExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorerStack = ExplorerController.GetExplorersByStack(stack);
+    response.json({explorers: explorerStack});
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,6 +15,11 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
+        static getExplorersByStack(explorers, stack){
+        const explorersInNodeWithStack = explorers.filter((explorer) => explorer.stacks == stack);
+        const usernamesOnStack = explorersInNodeWithStack.map((explorer) => explorer.githubUsername);
+        return usernamesOnStack;
+    }
 
 }
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -8,3 +8,9 @@ describe("Tests para ExplorerService", () => {
     });
 
 });
+describe("Test de ExplorerService", () => {
+    test("Nombre de explorers por Stack", () =>{
+        const nameExplorersByStack = ExplorerService.getExplorersByStack(explorers, "elm");
+        expect(nameExplorersByStack).toContain("ajolonauta6");
+    }); 
+});


### PR DESCRIPTION
**SOLUCIÓN**

Se realizó la modificación de 2 archivos con la creación de 2 nuevos métodos estáticos, uno en ExplorerController y otro en ExplorerService.

1. La solución consta de crear un método que reciba los parametros de "explorer" y "stack", se filtra la lista de explorers por "stack" y después con map, se crea un nuevo array con los "githubUsernames" de los explorers en la lista.

2. Posteriormente se crea un método en ExplorerController que reciba el parámetro de Stack, para llamar al método en ExplorerService.

3. Se crea un test, proporcionando un Stack y buscando en el arreglo con un .toContain el username que debería tener dicho stack.

4. Se agrega la parte necesaria en el server, donde se le dará el stack a buscar, llamando al método creado en ExplorerController.
