### PR TITLE
Add endpoint filtering explorers by stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorerByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersByStack = ExplorerController.getExplorerByStack(stack);
+    response.json(explorersByStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,15 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => 
+        {
+            if(explorer.stacks.some((explorerStack) => explorerStack === stack)){
+                return explorer;
+            }
+        });
+        return explorersByStack;
+    }
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorersController.test.js
+++ b/test/controllers/ExplorersController.test.js
@@ -1,0 +1,8 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+
+describe("Test para ExplorerController", () => {
+    test("Requerimiento 1: Traer todos los explorers por stack", () => {
+        const explorersInStack = ExplorerController.getExplorerByStack("javascript");
+        expect(explorersInStack.length).toBe(11);
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,32 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Regresar todos los explorers en una stack", () => {
+        const explorers = [{
+            "name": "Woopa1",
+            "githubUsername": "ajolonauta1",
+            "score": 1,
+            "mission": "node",
+            "stacks": [
+                "javascript",
+                "reasonML",
+                "elm"
+            ]
+        },
+        {
+            "name": "Woopa3",
+            "githubUsername": "ajolonauta3",
+            "score": 3,
+            "mission": "node",
+            "stacks": [
+                "elixir",
+                "groovy",
+                "reasonML"
+            ]
+        }
+        ];
+        const explorersInStack = ExplorerService.getExplorersByStack(explorers, "javascript");
+        expect(explorersInStack.length).toBe(1);
+    });
+
 });


### PR DESCRIPTION
# Add feature: filtering explorers by stack
1) Create a function in `ExplorerService.js`
![image](https://user-images.githubusercontent.com/48420854/166325660-2c8fae16-36c4-4320-b9dd-f6466fdde7aa.png)

2) Import this function in `ExplorerController.js`
![image](https://user-images.githubusercontent.com/48420854/166326044-8c2ff9c7-cad5-40a5-9737-98814f63276f.png)

3) Add an endpoint to get explorers in stack parameter
![image](https://user-images.githubusercontent.com/48420854/166326154-eaff8a83-1b30-4e40-85dc-3e4303770ab4.png)

4) Respond
![image](https://user-images.githubusercontent.com/48420854/166326436-55e5b19c-36c1-42d7-84ee-0cfe1bac8941.png)

