### PR TITLE
Nuevo Feature: Filtrar explorers por stack

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,17 +3,16 @@ module.exports = {
         "browser": true,
         "commonjs": true,
         "es2021": true,
-        "jest": true
+        "node": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {
         "ecmaVersion": "latest"
     },
     "rules": {
-        "no-unused-vars": "off",
         indent: ["error", 4],
         "linebreak-style": ["error", "unix"],
         quotes: ["error", "double"],
         semi: ["error", "always"]
     }
-};
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,6 +3,7 @@ module.exports = {
         "browser": true,
         "commonjs": true,
         "es2021": true,
+        "jest": true,
         "node": true
     },
     "extends": "eslint:recommended",
@@ -10,9 +11,10 @@ module.exports = {
         "ecmaVersion": "latest"
     },
     "rules": {
+        "no-unused-vars": "off",
         indent: ["error", 4],
         "linebreak-style": ["error", "unix"],
         quotes: ["error", "double"],
         semi: ["error", "always"]
     }
-}
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -23,9 +23,9 @@ class ExplorerController{
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
 
-    static getExplorersByStack(mission) {
+    static getExplorersByStack(stack) {
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByStack(explorers, mission);
+        return ExplorerService.filterByStack(explorers, stack);
     }
 }
 

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -1,3 +1,4 @@
+const { filterByStack } = require("../services/ExplorerService");
 const ExplorerService = require("../services/ExplorerService");
 const FizzbuzzService = require("../services/FizzbuzzService");
 const Reader = require("../utils/reader");
@@ -20,6 +21,11 @@ class ExplorerController{
     static getExplorersAmonutByMission(mission){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
+    }
+
+    static getExplorersByStack(mission) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService(filterByStack(explorers, mission))
     }
 }
 

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -1,4 +1,3 @@
-const { filterByStack } = require("../services/ExplorerService");
 const ExplorerService = require("../services/ExplorerService");
 const FizzbuzzService = require("../services/FizzbuzzService");
 const Reader = require("../utils/reader");

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -25,7 +25,7 @@ class ExplorerController{
 
     static getExplorersByStack(mission) {
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService(filterByStack(explorers, mission))
+        return ExplorerService.filterByStack(explorers, mission);
     }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersWithStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorersWithStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack) {
+        const explorersByStack = explorers.filter(explorer => explorer.stack == stack);
+        return explorersByStack;
+    }
 }
 
 module.exports = ExplorerService;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -17,7 +17,7 @@ class ExplorerService {
     }
 
     static filterByStack(explorers, stack) {
-        const explorersByStack = explorers.filter(explorer => explorer.stack == stack);
+        const explorersByStack = explorers.filter(explorer => explorer.stacks.includes(stack));
         return explorersByStack;
     }
 }

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,5 +6,9 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
-
+    test("Requerimiento 2: Obtener todos los explorers con cierto stack", () => {
+        const explorers = [{name: "explorer1", stack: "java"}, {name: "explorer2", stack:"javascript"}, {name: "explorer3", stack: "java"}];
+        const explorersInJava = ExplorerService.filterByStack(explorers, "java");
+        expect(explorersInJava).toEqual([{name: "explorer1", stack:"java"}, {name: "explorer3", stack: "java"}]);
+    });
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,8 +7,8 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
     test("Requerimiento 2: Obtener todos los explorers con cierto stack", () => {
-        const explorers = [{name: "explorer1", stack: "java"}, {name: "explorer2", stack:"javascript"}, {name: "explorer3", stack: "java"}];
+        const explorers = [{stacks: ["java", "javascript"]}, {stacks:["javascript", "css"]}, {stacks: ["java"]}];
         const explorersInJava = ExplorerService.filterByStack(explorers, "java");
-        expect(explorersInJava).toEqual([{name: "explorer1", stack:"java"}, {name: "explorer3", stack: "java"}]);
+        expect(explorersInJava).toEqual([{stacks: ["java", "javascript"]}, {stacks: ["java"]}]);
     });
 });


### PR DESCRIPTION
Endpoint para obtener la lista de explorers filtrados por un stack
-----------------------------------------------------------------------
El objetivo del nuevo feature es poder escribir una url como la siguiente, y obtener una lista de explorers que contenga en sus ``stacks`` el lenguaje solicitado:

`` http://localhost:3000/v1/explorers/stack/groovy ``
![image](https://user-images.githubusercontent.com/65133949/166336786-0cfa021f-e13f-480d-8162-648d605442d6.png)

Para hacer esto, se agregó un nuevo método a ``ExplorerService``, ``ExplorerController``  y al ``server``.

![image](https://user-images.githubusercontent.com/65133949/166336328-75641749-2911-4f11-b4c0-3fddbc183c35.png)

De esta manera:
- El ``server`` recibe un request GET con un lenguaje ``stack``, que
- Le pide a ``ExplorerController`` los explorers con ese stack, quien obtiene los explorers del archivo json, y
- Le pide a ``ExplorerService`` el filtrado de los explorers por ``stack``. 

### 1. ExplorerService
#### `` static filterByStack(mission, stack)``

Este método estático recibe una lista de ``explorers`` y un ``stack``. 
Con esa información usa el método **``filter``** con la lista de *explorers*, buscando a todos aquellos que contengan en su campo ``stacks`` el lenguaje ``stack`` solicitado.
Finalmente retorna la lista obtenida.

```javascript
static filterByStack(explorers, stack) {
        const explorersByStack = explorers.filter(explorer => explorer.stacks.includes(stack));
        return explorersByStack;
}
```
Este método es la base de la nueva funcionalidad, por lo que sí o sí lleva prueba:
``ExplorerService.test.js``
```javascript
test("Requerimiento 2: Obtener todos los explorers con cierto stack", () => {
        const explorers = [{stacks: ["java", "javascript"]}, {stacks:["javascript", "css"]}, {stacks: ["java"]}];
        const explorersInJava = ExplorerService.filterByStack(explorers, "java");
        expect(explorersInJava).toEqual([{stacks: ["java", "javascript"]}, {stacks: ["java"]}]);
});
```

### 2. ExplorerController
#### `` static getExplorersByStack(stack)``

*ExplorerController* es el intermediario entre la solicitud y los el servicio, se encarga de obtener la información del archivo *explorers.json* y hacer uso de métodos de *ExplorerService*.
Entonces, como es aquí donde obtenemos la lista de *explorers*, éste método únicamente necesita el parámetro``stack`` para invocar al método de *ExplorerService*:
1. Obtiene a los ``explorers`` del archivo
2. Devuelve la lista filtrada de ``ExplorerService.filterByStack`` con los parámetros ``explorers`` y ``stack``

```javascript
static getExplorersByStack(stack) {
    const explorers = Reader.readJsonFile("explorers.json");
    return ExplorerService.filterByStack(explorers, stack);
}
```

### 3. server
Como ya tenemos la funcionalidad, lo único que falta es definir un nuevo método GET para el request de un stack dado en una url tipo:
``"/v1/explorers/stack/:stack"``

1. Obtiene ``stack`` de los parámetros del request
2. Obtiene la lista de explorers con ese stack, invocando al método de ``ExplorerController``
3. Responde esa lista en formato json.
```javascript
app.get("/v1/explorers/stack/:stack", (request, response) => {
    const stack = request.params.stack;
    const explorersWithStack = ExplorerController.getExplorersByStack(stack);
    response.json(explorersWithStack);
});
```
