### PR TITLE
Requerimiento 4: Filtrar explorers por Stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+    
+    static getFilterStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersInStack = ExplorerController.getFilterStack(stack);
+    response.json(explorersInStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterStack(explorers, stack){
+        return explorers.filter((explorer) => explorer.stacks.includes(stack))
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,9 @@
+const ExplorerController = require("../../lib/controllers/ExplorerController");
+
+describe("Test de ExplorerController",() => {
+    test('Filtrar explorers por stack', () => {
+        const getFilterStack = ExplorerController.getFilterStack("javascript");
+
+        expect(getFilterStack[0].stacks).toContain('javascript')
+    })
+}) 

--- a/test/data/explorers_test.json
+++ b/test/data/explorers_test.json
@@ -1,0 +1,24 @@
+[
+    {
+      "name": "Woopa1",
+      "githubUsername": "ajolonauta1",
+      "score": 1,
+      "mission": "node",
+      "stacks": [
+        "javascript",
+        "reasonML",
+        "elm"
+      ]
+    },
+    {
+        "name": "Woopa3",
+        "githubUsername": "ajolonauta3",
+        "score": 3,
+        "mission": "node",
+        "stacks": [
+          "elixir",
+          "groovy",
+          "reasonML"
+        ]
+      }
+]

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,4 +1,7 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
+const fs = require("fs")
+const rawdata = fs.readFileSync('test/data/explorers_test.json');
+const explorers2 = JSON.parse(rawdata); 
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
@@ -7,4 +10,8 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Metodo filterStack", () => { 
+        const filterStack = ExplorerService.filterStack(explorers2, "javascript");
+        expect(filterStack[0].stacks).toContain('javascript')
+    });
 });


### PR DESCRIPTION
Explicación Requerimiento:

Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.

Ejemplo de url: localhost:3000/v1/explorers/stack/javascript.
Response: Todos los explorers que tengan en stack el valor recibido en la url: javascript. (este valor debe ser dinámico)

Cambios que se realizaron en el codigo:

En el archivo ExplorerService se creo un nuevo metodo:

![code](https://user-images.githubusercontent.com/87330021/166605343-c5b32c53-6b98-4ec5-a842-f0af3fa6e21d.png)

En el archivo ExplorerController se agrego un metodo para llamar el anterior creado:

![code](https://user-images.githubusercontent.com/87330021/166605431-95f6b4fd-f31f-455c-85ba-bb981e55fcf4.png)

En el archivo Server.js se creo el nuevo EndPoint para poder utilizar la nueva funcionalidad:

![code](https://user-images.githubusercontent.com/87330021/166605586-ab288c43-f402-4c70-8c02-10f83ae7d3b4.png)

Tambien se introdujeron pruebas para asegurar el funcionamiento

Se creo un json independiente del proyecto para las pruebas:

![code](https://user-images.githubusercontent.com/87330021/166605724-8c9d0490-411b-4ef4-a88b-be24290a3e59.png)

Prueba ExplorerController.test.js:

![code](https://user-images.githubusercontent.com/87330021/166605774-7d20c22b-9cd5-442c-a6ac-4316588a78a8.png)

Prueba ExplorerService.test.js: 

![code](https://user-images.githubusercontent.com/87330021/166605819-c86fb100-6f70-4fa6-bdb2-cb370ad0178b.png)

Agradeceria su revision y retroalimentación del requerimiento
Gracias