### PR TITLE
Nuevo Requerimiento: Obtener explorers por stack especifico

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStacks(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.explorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack",(request, response) =>{
+    const stack = request.params.stack;
+    const explorerByStack = ExplorerController.getExplorersByStacks(stack);
+    response.json(explorerByStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,6 +15,10 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
+    static explorersByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
 
 }
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,3 +1,4 @@
+const ExplorerController = require("../../lib/controllers/ExplorerController");
 const ExplorerService = require("./../../lib/services/ExplorerService");
 
 describe("Tests para ExplorerService", () => {
@@ -5,6 +6,12 @@ describe("Tests para ExplorerService", () => {
         const explorers = [{mission: "node"}];
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
+    });
+
+    test("Requerimiento 2: Devolver todos los explorers que tengan un stack especifico.", () =>{
+        const explorers = [{name: "raul", stacks: "javascript"}, {name: "raul2", stacks: ["javascript"]}, {name: "raul3", stacks: ["javascript", "groovy", "elm"]}, {name: "raul2", stacks: ["groovy"]}];
+        const explorersByStack = ExplorerService.explorersByStack(explorers, "javascript");
+        expect(explorersByStack).toStrictEqual([{name: "raul", stacks: "javascript"}, {name: "raul2", stacks: ["javascript"]}, {name: "raul3", stacks: ["javascript", "groovy", "elm"]}]);
     });
 
 });


### PR DESCRIPTION
### Nuevo Requerimiento:
Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.

| Endpoint | Request | Response |
|-----------|----------|------------|
| `localhost:3000/v1/explorers/stack/:stack` |  `localhost:3000/v1/explorers/stack/javascript` | Todos los explorers que tengan en stack el valor recibido en la url: javascript. (este valor debe ser dinámico). |


El requerimiento se desarrollo de la siguiente manera.
1. Se creó la función `explorersByStack` en el archivo ExplorerService.js, esta función se encarga de filtrar por el stack recibido desde el controlador. 

![code](https://user-images.githubusercontent.com/54995852/166618429-4c2f39bc-0304-44e1-9eba-ec8e81da87c8.png)

2. Se creó la función `getExplorersByStacks` en el controlador,  el cual recibe solo el stack y se encarga de enviarlo a la función  `explorersByStack`.  

![code](https://user-images.githubusercontent.com/54995852/166618595-315d830f-4872-4f49-9578-1800960b300b.png)

3. Se desarrolló una prueba para validar que el nuevo requerimiento está funcionando correctamente. 

![code](https://user-images.githubusercontent.com/54995852/166618700-7d50b152-3266-44da-965e-a9cb8e222e23.png)

4. Se desarrollo el endpoint para poder recibir el stack.

 
![code](https://user-images.githubusercontent.com/54995852/166618784-5da9eec4-668f-49f2-8add-0a12baf05769.png)

