### PR TITLE
Contribución Open Source 

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+    
+    static getExplorersByStack(nameStack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, nameStack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorers = ExplorerController.getExplorersByStack(stack);
+    response.json(explorers);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack){
+        return explorers.filter(explorer => explorer.stacks.includes(stack))
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,5 +6,9 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
-
+    test("Requerimiento 2: Calcular todos los explorers en una misión según su stack", () => {
+        const explorers = [{mission: "node", stacks:['javascript', 'css']}];
+        const explorersInNode = ExplorerService.getExplorersByStack(explorers, "javascript");
+        expect(explorersInNode.length).toBe(1);
+    });
 });


### PR DESCRIPTION
**### Práctica 4 de la Semana 4 - Contribución Open Source**

**Requerimiento:** 
Crear un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack, por ejemplo, Javascript.
La Url puede ser parecida a: `localhost:3000/v1/explorers/stack/javascript.`

**Dependencias**:
Se utilizó _Jest_ para desarrollar las pruebas de unidad de la nueva función, la cual puede consultarse en la carpeta **test**/services/ExplorerService.test.js

Se instaló _Express_ con la cual logramos inicializar un servidor en el puerto 3000 y crear el endpoint necesario para consumir la API. 
La configuración de este puede consultarse en la carpeta **lib**/server.js

**Documentación sobre la API.**
En el siguiente enlace a la documentación de Postman, se desglosa de manera detallada las peticiones implementadas, sus parámetros y retornos.
https://documenter.getpostman.com/view/20762518/UyrGAtjG
