### PR TITLE
Se agrega endpoint para filtrar por stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersUsernamesByStack(stack) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,13 @@ app.get("/v1/explorers/:mission", (request, response) => {
     response.json(explorersInMission);
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersInStack = ExplorerController.getExplorersUsernamesByStack(stack);
+    response.json(explorersInStack);
+});
+
+
 app.get("/v1/explorers/amount/:mission", (request, response) => {
     const mission = request.params.mission;
     const explorersAmountInMission = ExplorerController.getExplorersAmonutByMission(mission);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,10 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack) {
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
 }
 
 module.exports = ExplorerService;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -5,6 +5,10 @@ describe("Tests para ExplorerService", () => {
         const explorers = [{mission: "node"}];
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
+    })
+    test("Requerimiento 2: Obtener explorers que contengan X stack", () => {
+        const explorers = [{ name: "Woopa1", stacks: ["javascript", "reasonML", "elm"] }, { name: "Woopa2", stacks: ["javascript", "groovy", "elm"] }, { name: "Woopa3", stacks: ["elixir", "groovy", "reasonML"] }];
+        const explorersInStack = ExplorerService.getExplorersByStack(explorers, "elm");
+        expect(explorersInStack.length).toBe(2);
     });
-
 });


### PR DESCRIPTION
Se envia PR con los cambios requeridos.

**Requerimento:**
Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.

**Modificaciones:**
- ExplorerController.js
Se agrega metodo _getExplorersUsernamesByStack_ a la clase _ExplorerController_. Este recibe el parametro _stack_.
A continuacion se invoca el metodo _getExplorersByStack_ de la clase _ExplorerService_ y regresa su valor.
- Server.js
Se agrega nuevo endpoint **/v1/explorers/stack/:stack**, se recibe como parametro _stack_ y se invoca el metodo _getExplorersUsernamesByStack_, se regresa y muestra su valor.
- ExplorerService.js
Se agrega metodo _getExplorersByStack_ el cual recibe los parametros _explorers_ y _stack_, filtra el objeto _explorers_ utilizando la funcion [includes](https://developer.mozilla.org/es/docs/Web/JavaScript/Reference/Global_Objects/Array/includes), para solo obtener los elementos que contengan el stack que se recibio en el parametro.
- ExplorerService.test.js
Se agrega una nueva prueba, se crea un objeto _explorers_, se invoca el metodo getExplorersByStack de la clase ExplorerService y se le envia el objeto explorers y el nombre de un stack (como prueba se envio "elm"), si la cantidad de elementos retornados es igual a la que se espera (en este caso, 2) se toma como prueba exitosa.

**Comentarios:**
Al momento de hacer git add solamente se agregaron agregaron al staging los archivos mencionados anteriormente. 
Se realizaron pruebas locales para ver que funcionara de manera correcta. 
Para ver el funcionamiento se utilizo hoppscotch y curl.

![image](https://user-images.githubusercontent.com/16631910/166650550-d3c89c14-bba4-4d4b-a3a6-349f2b4e2112.png)

