### PR TITLE
Added option to get Explorers by Stack.

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorers = ExplorerController.getExplorersByStack(stack);
+    response.json({stack: stack, explorers: explorers});
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,12 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack)
+    {
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack))
+
+        return explorersByStack;
+    }
 }
 
 module.exports = ExplorerService;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,9 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Calcular todos los explorers que tengan un stack", () => {
+        const explorers = [{stacks: ["javascript", "groovy"]}, {stacks: ["elixir", "groovy"]}, {stacks: ["elm", "javascript"]}];
+        const explorersByStack = ExplorerService.getExplorersByStack(explorers, "javascript");
+        expect(explorersByStack.length).toBe(2);
+    });
 });


### PR DESCRIPTION
## Requerimiento

Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.

* Ejemplo de url: localhost:3000/v1/explorers/stack/javascript.
* Response: Todos los explorers que tengan en stack el valor recibido en la url: javascript. (este valor debe ser dinámico)

## Implementación

1. Creé un fork del repo https://github.com/visualpartnership/fizzbuzz en https://github.com/rickygzz/fizzbuzz-visualpartnership
2. Cloné mi repositorio `git clone https://github.com/rickygzz/fizzbuzz-visualpartnership`
3. Creé una prueba en `test/services/ExplorerService.test.js`

```
    test("Requerimiento 2: Calcular todos los explorers que tengan un stack", () => {
        const explorers = [{stacks: ["javascript", "groovy"]}, {stacks: ["elixir", "groovy"]}, {stacks: ["elm", "javascript"]}];
        const explorersByStack = ExplorerService.getExplorersByStack(explorers, "javascript");
        expect(explorersByStack.length).toBe(2);
    });
```

4.  Implementé el método para filtrar los explorers en `lib/services/ExplorerService.js`

```
    static getExplorersByStack(explorers, stack)
    {
        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack))

        return explorersByStack;
    }
```

5. Creé el método controlador para comunicarse con el servidor `lib/controllers/ExplorerController.js`

```
    static getExplorersByStack(stack){
        const explorers = Reader.readJsonFile("explorers.json");
        return ExplorerService.getExplorersByStack(explorers, stack);
    }
```

6.  Añadí el EndPoint en `lib/server.js`

```
app.get("/v1/explorers/stack/:stack", (request, response) => {
    const stack = request.params.stack;
    const explorers = ExplorerController.getExplorersByStack(stack);
    response.json({stack: stack, explorers: explorers});
});
```

## Diseño actual

```mermaid
graph TD;
    Reader-->ExplorerService;
    FizzbuzzService;
    ExplorerService-->ExplorerController
    FizzbuzzService-->ExplorerController
    ExplorerController-->Server
```

## Nuevos métodos

```mermaid
classDiagram
    class ExplorerController
    ExplorerController: +getExplorersByStack(stack)
```

```mermaid
classDiagram
    class ExplorerService
    ExplorerService: +getExplorersByStack(explorers, stack)
```

## Endpoints disponibles

- /v1/explorers/:mission
- /v1/explorers/amount/:mission
- /v1/explorers/usernames/:mission
- /v1/fizzbuzz/:score
- /v1/explorers/stack/:stack ⭐ (agregado)