### PR TITLE
Contribución OpenSource

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -24,7 +24,7 @@ class ExplorerController{
 
     static filterByStack(stack){
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByStack(explorers, stack)
+        return ExplorerService.filterByStack(explorers, stack);
     }
 }
 

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static filterByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack)
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,7 +36,7 @@ app.get("/v1/explorers/stack/:stack", (request, response) => {
     const stack = request.params.stack;
     const explorersByStack = ExplorerController.filterByStack(stack);
     response.json(explorersByStack);
-})
+});
 
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersByStack = ExplorerController.filterByStack(stack);
+    response.json(explorersByStack);
+})
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controller/ExplorerController.test.js
+++ b/test/controller/ExplorerController.test.js
@@ -1,0 +1,9 @@
+const ExplorerController = require ('./../../lib/controllers/ExplorerController')
+
+describe("Test para ExplorerController", () =>{
+    test('Filtrar explorers por su stack', () => { 
+        const stack = "javascript";
+        const explorersInJS = ExplorerController.filterByStack(stack);
+        expect(explorersInJS.length).toBe(11);
+     })
+})

--- a/test/controller/ExplorerController.test.js
+++ b/test/controller/ExplorerController.test.js
@@ -1,9 +1,9 @@
-const ExplorerController = require ('./../../lib/controllers/ExplorerController')
+const ExplorerController = require ("./../../lib/controllers/ExplorerController");
 
 describe("Test para ExplorerController", () =>{
-    test('Filtrar explorers por su stack', () => { 
+    test("Filtrar explorers por su stack", () => { 
         const stack = "javascript";
         const explorersInJS = ExplorerController.filterByStack(stack);
         expect(explorersInJS.length).toBe(11);
-     })
-})
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,10 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento OpenSource: Filtrar explorers por su stack", () =>{
+        const explorers = [{stacks: ["javascript"]}];
+        const explorersInJS = ExplorerService.filterByStack(explorers, "javascript");
+        expect(explorersInJS.length).toBe(1);
+    });
+
 });


### PR DESCRIPTION
># Contribución OpenSource

### Para resolver este requerimiento se siguieron los siguientes pasos:

1.  ¿Cómo sabes que el código funciona? 
**Exacto, con pruebas de unidad**
El primer paso fue crear una prueba de unidad en **ExplorerService** para validar que nuestro método funcionara.
```
test("Requerimiento OpenSource: Filtrar explorers por su stack", () =>{
        const explorers = [{stacks: ["javascript"]}];
        const explorersInJS = ExplorerService.filterByStack(explorers, "javascript");
        expect(explorersInJS.length).toBe(1);
    });
```

2. El paso dos fue crear el método en la clase ExplorerService, funciona de la siguiente forma: 
del archivo **explorers.json** se filtran los explorers por su stack, ¿fácil, no?, realmente necesitamos otro método, **includes()**, sin este método solo regresaría un resultado, ya que este método valida si una cadena existe dentro de otra.

```
static filterByStack(explorers, stack){
        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
        return explorersByStack;
    }
```

3. El paso número tres fue crear el controller para usarlo en el servidor, por lo tanto, hice una prueba de unidad para validar el método de la clase ExplorerController.
```
describe("Test para ExplorerController", () =>{
    test('Filtrar explorers por su stack', () => { 
        const stack = "javascript";
        const explorersInJS = ExplorerController.filterByStack(stack);
        expect(explorersInJS.length).toBe(11);
     })
```

4. El paso cuatro fue crear el método en la clase ExplorerController, esta vez solo necesitamos llamar a la función de la clase ExplorerService **filterByStack** para que este pueda funcionar.
```
static filterByStack(stack){
        const explorers = Reader.readJsonFile("explorers.json");
        return ExplorerService.filterByStack(explorers, stack)
    }
```
5. El quinto y último paso fue crear el endpoint que regresa la lista de explorers filtrados por el stack.
```
app.get("/v1/explorers/stack/:stack", (request, response) => {
    const stack = request.params.stack;
    const explorersByStack = ExplorerController.filterByStack(stack);
    response.json(explorersByStack);
})
```

![image](https://user-images.githubusercontent.com/99108837/167068585-e7a763cc-9234-4f20-8463-20c17e8b2477.png)
