### PR TITLE
Funcion para filtrar explorers por stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -2,24 +2,29 @@ const ExplorerService = require("../services/ExplorerService");
 const FizzbuzzService = require("../services/FizzbuzzService");
 const Reader = require("../utils/reader");
 
-class ExplorerController{
-    static getExplorersByMission(mission){
+class ExplorerController {
+    static getExplorersByMission(mission) {
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.filterByMission(explorers, mission);
     }
 
-    static applyFizzbuzz(score){
+    static applyFizzbuzz(score) {
         return FizzbuzzService.applyValidationInNumber(score);
     }
 
-    static getExplorersUsernamesByMission(mission){
+    static getExplorersUsernamesByMission(mission) {
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getExplorersUsernamesByMission(explorers, mission);
     }
 
-    static getExplorersAmonutByMission(mission){
+    static getExplorersAmonutByMission(mission) {
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
+    }
+
+    static getExplorersByStack(stack) {
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
     }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,7 @@ app.use(express.json());
 const port = 3000;
 
 app.get("/", (request, response) => {
-    response.json({message: "FizzBuzz Api welcome!"});
+    response.json({ message: "FizzBuzz Api welcome!" });
 });
 
 app.get("/v1/explorers/:mission", (request, response) => {
@@ -17,22 +17,27 @@ app.get("/v1/explorers/:mission", (request, response) => {
 app.get("/v1/explorers/amount/:mission", (request, response) => {
     const mission = request.params.mission;
     const explorersAmountInMission = ExplorerController.getExplorersAmonutByMission(mission);
-    response.json({mission: request.params.mission, quantity: explorersAmountInMission});
+    response.json({ mission: request.params.mission, quantity: explorersAmountInMission });
 });
 
 app.get("/v1/explorers/usernames/:mission", (request, response) => {
     const mission = request.params.mission;
     const explorersUsernames = ExplorerController.getExplorersUsernamesByMission(mission);
-    response.json({mission: request.params.mission, explorers: explorersUsernames});
+    response.json({ mission: request.params.mission, explorers: explorersUsernames });
 });
 
 app.get("/v1/fizzbuzz/:score", (request, response) => {
     const score = parseInt(request.params.score);
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
-    response.json({score: score, trick: fizzbuzzTrick});
+    response.json({ score: score, trick: fizzbuzzTrick });
+});
+
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersInStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorersInStack);
 });
 
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });
-

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,7 +36,6 @@ app.get("/v1/explorers/stack/:stack", (request, response) => {
     const stack = request.params.stack;
     const explorersInStack = ExplorerController.getExplorersByStack(stack);
     response.json(explorersInStack);
-
 });
 
 app.listen(port, () => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,6 +36,7 @@ app.get("/v1/explorers/stack/:stack", (request, response) => {
     const stack = request.params.stack;
     const explorersInStack = ExplorerController.getExplorersByStack(stack);
     response.json(explorersInStack);
+
 });
 
 app.listen(port, () => {

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -1,21 +1,29 @@
 class ExplorerService {
 
-    static filterByMission(explorers, mission){
+    static filterByMission(explorers, mission) {
         const explorersByMission = explorers.filter((explorer) => explorer.mission == mission);
         return explorersByMission;
     }
 
-    static getAmountOfExplorersByMission(explorers, mission){
+    static getAmountOfExplorersByMission(explorers, mission) {
         const explorersByMission = ExplorerService.filterByMission(explorers, mission);
         return explorersByMission.length;
     }
 
-    static getExplorersUsernamesByMission(explorers, mission){
+    static getExplorersUsernamesByMission(explorers, mission) {
         const explorersByMission = ExplorerService.filterByMission(explorers, mission);
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack) {
+        const explorersByStack = explorers.filter((explorer) => {
+            if (explorer.stacks.includes(stack)) {
+                return explorer;
+            }
+        });
+        return explorersByStack;
+    }
 }
 
 module.exports = ExplorerService;


### PR DESCRIPTION
Para filtrar a los explores que tuviera en su stack la tecnología solicitada, escribí dentro de [ExplorerService](https://github.com/Ismogar/4_contribution/blob/master/lib/services/ExplorerService.js) una función que recibiría como parámetros el array de explorers en el que se hará la búsqueda y el stack que se buscara. Utilice filter para guardar solo los explorers que incluyeran el stack solicitado e include para buscar en el array donde se guardan los stacks.
```javascript
static filterByStack(explorers, stack) {
    const explorersByStack = explorers.filter((explorer) => {
        if (explorer.stacks.includes(stack)) {
            return explorer;
        }
    });
    return explorersByStack;
}
```
Añadí el acceso a la función en [ExplorerController](https://github.com/Ismogar/4_contribution/blob/master/lib/controllers/ExplorerController.js). Recibe el stack que se quiere buscar, llama a Reader para guardar el contenido del json que contiene la información de los explorers en un array de objetos y regresa el resultado de mandar a ExplorerService.filterByStack el parámetro recibido y el array de objetos. 
```javascript
static getExplorersByStack(stack) {
    const explorers = Reader.readJsonFile("explorers.json");
    return ExplorerService.filterByStack(explorers, stack);
}
```
En [server](https://github.com/Ismogar/4_contribution/blob/master/lib/server.js) añadí el endpoint que llama a la función en el controller.
```javascript
app.get("/v1/explorers/stack/:stack", (request, response) => {
    const stack = request.params.stack;
    const explorersInStack = ExplorerController.getExplorersByStack(stack);
    response.json(explorersInStack);
});
```
