### PR TITLE
4 Contribución Open Source:  Filtrar a los explorers por Stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -1,6 +1,6 @@
 const ExplorerService = require("../services/ExplorerService");
 const FizzbuzzService = require("../services/FizzbuzzService");
-const Reader = require("../utils/reader");
+const Reader = require("../utils/Reader");
 
 class ExplorerController{
     static getExplorersByMission(mission){
@@ -20,6 +20,11 @@ class ExplorerController{
     static getExplorersAmonutByMission(mission){
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
+    }
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        const explorersStack = ExplorerService.filterByStack(explorers, stack);
+        return explorersStack;
     }
 }
 

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -1,6 +1,6 @@
 const ExplorerService = require("../services/ExplorerService");
 const FizzbuzzService = require("../services/FizzbuzzService");
-const Reader = require("../utils/Reader");
+const Reader = require("../utils/reader");
 
 class ExplorerController{
     static getExplorersByMission(mission){

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,6 +31,11 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
     response.json({score: score, trick: fizzbuzzTrick});
 });
+app.get("/v1/stack/:stacks", (request, response) => {
+    const stack = request.params.stacks;
+    const stackExplorers = ExplorerController.getExplorersByStack(stack);
+    response.json(stackExplorers);
+});
 
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,6 +15,10 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
+    static filterByStack (explorers, stacks) {
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stacks));
+        return explorersByStack;
+    }
 
 }
 

--- a/test/controllers/ExplorersController.test.js
+++ b/test/controllers/ExplorersController.test.js
@@ -1,0 +1,8 @@
+const ExplorerController = require("../../lib/controllers/ExplorerController");
+
+describe("Tests para ExplorerController", () => {
+    test("Prueba para GetExplorersByStack", () => {
+        const prueba1 = ExplorerController.getExplorersByStack("javascript");
+        expect(prueba1.length).toBe(11);
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,5 +1,5 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
-const Reader = require("../../lib/utils/Reader");
+const Reader = require("../../lib/utils/reader");
 
 
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,4 +1,7 @@
 const ExplorerService = require("./../../lib/services/ExplorerService");
+const Reader = require("../../lib/utils/Reader");
+
+
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
@@ -6,5 +9,10 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
+    test("Contribución: filtrar por Stack", () =>{
+        const explorers = Reader.readJsonFile("./explorers.json");
+        const explorersStack = ExplorerService.filterByStack(explorers, "javascript");
+        expect(explorersStack.length).toBe(11);
+    })
 
 });


### PR DESCRIPTION
# Contribución Open Source para poder filtrar a los Explorers por Stack. 

## Nuevo requerimiento: Crea un endpoint para filtrar los explorers por stack
| Endpoint | Request | Response |
|---|---|---|
| `localhost:3000/v1/stack/:stacks` | `localhost:3000/v1/explorers/stack/javascript` | Deberás obtener la lista de explorers que tengan 'Javascript' en sus stacks |

## Solución
### 1. Filtrando por Stack
Creamos un nuevo método static `filterByStack` dentro del archivo `lib/services/ExplorerService.js` para filtrar el registro del archivo json segun los Stacks
![filterByStack](https://user-images.githubusercontent.com/84040594/167323568-abeddfc9-c565-4f72-ab99-ccd29dffeef6.png "filterByStack")
Se le agrega la prueba para validar el funcionamiento del código.
![testFilterByStack](https://user-images.githubusercontent.com/84040594/167323975-e09c15ad-f87b-4faf-96d1-b494fed13c63.png "testFilterByStack")

### 2. Aplicando el método al Controller
Creando un método static `getExplorersByStack` dentro de `lib/controllers/ExplorerController.js` para que sea la conexión entre la funcionalidad y el server.
![image](https://user-images.githubusercontent.com/84040594/167324139-92cc576a-3314-4f16-a5d0-3019199a8cd8.png)
La prueba del controller
![testGetExplorersByStack](https://user-images.githubusercontent.com/84040594/167324449-f6090b26-546b-4661-b13a-516467a3836d.png "testGetExplorersByStack")

### 3. Agregando endopoint en el Server
Creación del endpoint.
![image](https://user-images.githubusercontent.com/84040594/167324770-54e69a9c-5327-4274-bd50-ca001d6a8d72.png)

## Request y Response 

![reasonML](https://user-images.githubusercontent.com/84040594/167324835-8cf6fdbe-dae8-4962-ac2f-a2b3b1c1f091.png)

![javascript](https://user-images.githubusercontent.com/84040594/167325105-6c425d2c-6640-4345-852e-52acd63741c0.png)

![groovy](https://user-images.githubusercontent.com/84040594/167325138-062c1c16-255d-475f-8079-b0175bf3c031.png)

![elixir](https://user-images.githubusercontent.com/84040594/167325194-2bb46ba4-79ca-4476-94b8-193b1449b4b9.png)


