### PR TITLE
add: explorers filtered by stack endpoint 

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersFilteredByStack(stacks){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stacks);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stacks", (request, response) => {
+    const stacks = request.params.stacks;
+    const explorersFilteredByStack = ExplorerController.getExplorersFilteredByStack(stacks);
+    response.json(explorersFilteredByStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,17 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+
+        if(explorersByStack.length > 0){
+            return explorersByStack;
+        }
+        else {
+            return "No explorers found";
+        }
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,15 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+
+describe("Tests para ExplorerController", () => {
+    test("Requirement 1: Get all explorers that have the same stack", () => {
+        const explorersFilteredByStack_1 = ExplorerController.getExplorersFilteredByStack("javascript");
+        const explorersFilteredByStack_2 = ExplorerController.getExplorersFilteredByStack("reasonML");
+        const explorersFilteredByStack_3 = ExplorerController.getExplorersFilteredByStack("elm");
+        const explorersFilteredByStack_4 = ExplorerController.getExplorersFilteredByStack("django");
+
+        expect(explorersFilteredByStack_1).toHaveLength(11);
+        expect(explorersFilteredByStack_2).toHaveLength(9);
+        expect(explorersFilteredByStack_3).toHaveLength(12);
+        expect(explorersFilteredByStack_4).toBe("No explorers found");
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,17 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requirement 2 : Get all explorers that have the same stack", () => {
+        const explorers1 = [{stacks: ["javascript", "react", "node"]}];
+        const explorers2 = [];
+        const explorers3 = [{stacks: ""}];
+
+        const explorersInStack1 = ExplorerService.getExplorersByStack(explorers1, "javascript");
+        const explorersInStack2 = ExplorerService.getExplorersByStack(explorers2, "javascript");
+        const explorersInStack3 = ExplorerService.getExplorersByStack(explorers3, "javascript");
+
+        expect(explorersInStack1.length).toBe(1);
+        expect(explorersInStack2).toBe("No explorers found");
+        expect(explorersInStack3).toBe("No explorers found");
+    });
 });


### PR DESCRIPTION
# Adding a new endpoint that filters 'explorers' by their stacks

## Create 'getExplorersByStack' in ExplorerService.js which filters 'explorers' if their stacks include the one received (also checks if the stack exists, and if not, returns 'no explorers found')

```
static getExplorersByStack(explorers, stack){
    const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));

    if(explorersByStack.length > 0){
        return explorersByStack;
    }
    else {
        return "No explorers found";
    }
}
```

## Testing 'getExplorersByStack' in ExplorerService.test.js (jest)

```
test("Requirement 2 : Get all explorers that have the same stack", () => {
    const explorers1 = [{stacks: ["javascript", "react", "node"]}];
    const explorers2 = [];
    const explorers3 = [{stacks: ""}];

    const explorersInStack1 = ExplorerService.getExplorersByStack(explorers1, "javascript");
    const explorersInStack2 = ExplorerService.getExplorersByStack(explorers2, "javascript");
    const explorersInStack3 = ExplorerService.getExplorersByStack(explorers3, "javascript");

    expect(explorersInStack1.length).toBe(1);
    expect(explorersInStack2).toBe("No explorers found");
    expect(explorersInStack3).toBe("No explorers found");
});
```

## Create 'getExplorersFilteredByStack' in ExplorerController.js which reads 'explorers.json' and filters them by the recieved stack

```
static getExplorersFilteredByStack(stacks){
    const explorers = Reader.readJsonFile("explorers.json");
    return ExplorerService.getExplorersByStack(explorers, stacks);
}
```

## Testing 'getExplorersFilteredByStack' in ExplorerController.test.js (jest)

```
describe("Tests para ExplorerController", () => {
    test("Requirement 1: Get all explorers that have the same stack", () => {
        const explorersFilteredByStack_1 = ExplorerController.getExplorersFilteredByStack("javascript");
        const explorersFilteredByStack_2 = ExplorerController.getExplorersFilteredByStack("reasonML");
        const explorersFilteredByStack_3 = ExplorerController.getExplorersFilteredByStack("elm");
        const explorersFilteredByStack_4 = ExplorerController.getExplorersFilteredByStack("django");

        expect(explorersFilteredByStack_1).toHaveLength(11);
        expect(explorersFilteredByStack_2).toHaveLength(9);
        expect(explorersFilteredByStack_3).toHaveLength(12);
        expect(explorersFilteredByStack_4).toBe("No explorers found");
    });
});
```

## Finally, creating a new endpoint in server.js which takes the 'stacks' parameter and responds with a filtered json

```
app.get("/v1/explorers/stack/:stacks", (request, response) => {
    const stacks = request.params.stacks;
    const explorersFilteredByStack = ExplorerController.getExplorersFilteredByStack(stacks);
    response.json(explorersFilteredByStack);
});
```