### PR TITLE
Agregando: explorersByStack Endpoint

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack)
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -24,7 +24,7 @@ class ExplorerController{
 
     static getExplorersByStack(stack){
         const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByStack(explorers, stack)
+        return ExplorerService.filterByStack(explorers, stack);
     }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -33,9 +33,9 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
 });
 
 app.get("/v1/explorers/stack/:stack", (req, res)=>{
-    const stack = req.params.stack
-    res.send(ExplorerController.getExplorersByStack(stack))
-})
+    const stack = req.params.stack;
+    res.send(ExplorerController.getExplorersByStack(stack));
+});
 
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,11 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (req, res)=>{
+    const stack = req.params.stack
+    res.send(ExplorerController.getExplorersByStack(stack))
+})
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -18,8 +18,8 @@ class ExplorerService {
 
     static filterByStack(explorers, stack){
         return explorers.filter(explorer => {
-            return explorer.stacks.find(tech => tech === stack) != undefined
-        })
+            return explorer.stacks.find(tech => tech === stack) != undefined;
+        });
     }
 
 }

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,13 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack){
+        console.log(explorers);
+        return explorers.filter(explorer => {
+            return explorer.stacks.find(tech => tech === stack) != undefined
+        })
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -17,7 +17,6 @@ class ExplorerService {
     }
 
     static filterByStack(explorers, stack){
-        console.log(explorers);
         return explorers.filter(explorer => {
             return explorer.stacks.find(tech => tech === stack) != undefined
         })

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
+    "test": "node node_modules/jest/bin/jest",
     "linter": "node ./node_modules/eslint/bin/eslint.js",
     "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
     "server": "node ./lib/server.js"

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,22 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Obtener explorers por filtro de stack", ()=>{
+        const explorers = [
+            {
+              "name": "Woopa1",
+              "githubUsername": "ajolonauta1",
+              "score": 1,
+              "mission": "node",
+              "stacks": [
+                "javascript",
+                "reasonML",
+                "elm"
+              ]
+            }
+        ]
+        const filtered_explorers = ExplorerService.filterByStack(explorers, "javascript")
+        expect(filtered_explorers).toEqual(explorers)
+    })
+
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -10,19 +10,19 @@ describe("Tests para ExplorerService", () => {
     test("Requerimiento 2: Obtener explorers por filtro de stack", ()=>{
         const explorers = [
             {
-              "name": "Woopa1",
-              "githubUsername": "ajolonauta1",
-              "score": 1,
-              "mission": "node",
-              "stacks": [
-                "javascript",
-                "reasonML",
-                "elm"
-              ]
+                "name": "Woopa1",
+                "githubUsername": "ajolonauta1",
+                "score": 1,
+                "mission": "node",
+                "stacks": [
+                    "javascript",
+                    "reasonML",
+                    "elm"
+                ]
             }
-        ]
-        const filtered_explorers = ExplorerService.filterByStack(explorers, "javascript")
-        expect(filtered_explorers).toEqual(explorers)
-    })
+        ];
+        const filtered_explorers = ExplorerService.filterByStack(explorers, "javascript");
+        expect(filtered_explorers).toEqual(explorers);
+    });
 
 });


### PR DESCRIPTION
Cambios:
- Agregue un test para el **_Requerimiento 2: Obtener explorers por filtro de stack_**
- Añadi metodo statico `filterByStack(explorers, stack)` a la clase `ExplorerService` para que realiza la logica del programa
- Agregue metodo statico `getExplorersByStack(stack)` a la clase `ExplorerController` para la capa de Controlador.
- Agregue endpoint `"/v1/explorers/stack/:stack"` para exponer la informacion producida por el controller
