### PR TITLE
add: Ruta para poder obtener una lista de exploradores que contengan un stack especifico dentro de sus stacks

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorerWithStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorerWithStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorerWithStack = ExplorerController.getExplorerWithStack(stack);
+    response.json({stack: stack, explorers: explorerWithStack});
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorerWithStack(explorers, stack){
+        const explorersBystack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersBystack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,249 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+
+
+describe("Test for Explorer Controllers", () => {
+
+    test("Test to get Explorers By Mission", () => {
+        const result = ExplorerController.getExplorersByMission("node");
+        expect(result).toStrictEqual([{
+            "githubUsername": "ajolonauta1",
+            "mission": "node",
+            "name": "Woopa1",
+            "score": 1,
+            "stacks": ["javascript", "reasonML", "elm"]
+        }, {
+            "githubUsername": "ajolonauta2",
+            "mission": "node",
+            "name": "Woopa2",
+            "score": 2,
+            "stacks": ["javascript", "groovy", "elm"]
+        }, {
+            "githubUsername": "ajolonauta3",
+            "mission": "node",
+            "name": "Woopa3",
+            "score": 3,
+            "stacks": ["elixir", "groovy", "reasonML"]
+        }, {
+            "githubUsername": "ajolonauta4",
+            "mission": "node",
+            "name": "Woopa4",
+            "score": 4,
+            "stacks": ["javascript"]
+        }, {
+            "githubUsername": "ajolonauta5",
+            "mission": "node",
+            "name": "Woopa5",
+            "score": 5,
+            "stacks": ["javascript", "elixir", "elm"]
+        }, {
+            "githubUsername": "ajolonauta11",
+            "mission": "node",
+            "name": "Woopa11",
+            "score": 11,
+            "stacks": ["javascript", "elixir", "groovy", "reasonML", "elm"]
+        }, {
+            "githubUsername": "ajolonauta12",
+            "mission": "node",
+            "name": "Woopa12",
+            "score": 12,
+            "stacks": ["javascript", "elixir", "groovy", "reasonML", "elm"]
+        }, {
+            "githubUsername": "ajolonauta13",
+            "mission": "node",
+            "name": "Woopa13",
+            "score": 13,
+            "stacks": ["javascript", "elixir", "groovy", "reasonML", "elm"]
+        }, {
+            "githubUsername": "ajolonauta14",
+            "mission": "node",
+            "name": "Woopa14",
+            "score": 14,
+            "stacks": ["javascript", "elixir", "groovy", "reasonML", "elm"]
+        }, {
+            "githubUsername": "ajolonauta15",
+            "mission": "node",
+            "name": "Woopa15",
+            "score": 15,
+            "stacks": ["javascript", "elixir", "groovy", "reasonML", "elm"]
+        }]);
+    });
+
+    test("Test to get Explorers Usernames By Mission", () => {
+        const result = ExplorerController.getExplorersAmonutByMission("node");
+        expect(result).toBe(10);
+    });
+
+    test(" Test to get Explorers Amonut By Mission", () => {
+        const result = ExplorerController.getExplorersUsernamesByMission("node");
+        expect(result).toStrictEqual(["ajolonauta1", "ajolonauta2", "ajolonauta3", "ajolonauta4", "ajolonauta5", "ajolonauta11", "ajolonauta12", "ajolonauta13", "ajolonauta14", "ajolonauta15"]);
+    });
+
+    test("Test to get Explorers By Mission", () => {
+        const result = ExplorerController.getExplorerWithStack("javascript");
+        expect(result).toStrictEqual(
+            [
+                {
+                    "githubUsername": "ajolonauta1",
+                    "mission": "node",
+                    "name": "Woopa1",
+                    "score": 1,
+                    "stacks":  [
+                        "javascript",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta2",
+                    "mission": "node",
+                    "name": "Woopa2",
+                    "score": 2,
+                    "stacks":  [
+                        "javascript",
+                        "groovy",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta4",
+                    "mission": "node",
+                    "name": "Woopa4",
+                    "score": 4,
+                    "stacks":  [
+                        "javascript",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta5",
+                    "mission": "node",
+                    "name": "Woopa5",
+                    "score": 5,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta9",
+                    "mission": "java",
+                    "name": "Woopa9",
+                    "score": 9,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "groovy",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta10",
+                    "mission": "java",
+                    "name": "Woopa10",
+                    "score": 10,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "groovy",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta11",
+                    "mission": "node",
+                    "name": "Woopa11",
+                    "score": 11,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "groovy",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta12",
+                    "mission": "node",
+                    "name": "Woopa12",
+                    "score": 12,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "groovy",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta13",
+                    "mission": "node",
+                    "name": "Woopa13",
+                    "score": 13,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "groovy",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta14",
+                    "mission": "node",
+                    "name": "Woopa14",
+                    "score": 14,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "groovy",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+                {
+                    "githubUsername": "ajolonauta15",
+                    "mission": "node",
+                    "name": "Woopa15",
+                    "score": 15,
+                    "stacks":  [
+                        "javascript",
+                        "elixir",
+                        "groovy",
+                        "reasonML",
+                        "elm",
+                    ],
+                },
+            ]
+        );
+    });
+
+});
+
+describe("Test for explorer controller FIZZBUZZ service", () => {
+    test("Test 1 to apply Validation In a given number (1)", function () {
+        const result = ExplorerController.applyFizzbuzz(1);
+        expect(result).toBe(1);
+    });
+
+    test("Test 2 to apply Validation In a given number(3)", function () {
+        const result = ExplorerController.applyFizzbuzz(3);
+        expect(result).toBe("FIZZ");
+    });
+
+    test("Test 3 to apply Validation In a given number(5)", function () {
+        const result = ExplorerController.applyFizzbuzz(5);
+        expect(result).toBe("BUZZ");
+    });
+
+    test("Test 4 to apply Validation In a given number(15)", function () {
+        const result = ExplorerController.applyFizzbuzz(15);
+        expect(result).toBe("FIZZBUZZ");
+    });
+
+    test("Test 5 to apply Validation In a given number(90)", function () {
+        const result = ExplorerController.applyFizzbuzz(90);
+        expect(result).toBe("FIZZBUZZ");
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,22 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    test("Requerimiento 2: Cantidad de explorers por mission",() =>{
+        const explorers = [{mission: "node"},{mission: "node"},{mission: "node"},{mission: "java"},{mission: "java"},{mission: "java"},{mission: "java"}];
+        const explorersByMission = ExplorerService.getAmountOfExplorersByMission(explorers, "node");
+        expect(explorersByMission).toBe(3);
+    });
+     
+    test("Requerimiento 3 por Usernames",()=>{
+        const explorers = [{mission: "node", githubUsername: "Testjolonauta1"},{mission: "node", githubUsername: "Testjolonauta2"},{mission: "node", githubUsername: "Testjolonauta3"},{mission: "java", githubUsername: "Testjolonauta4"},{mission: "java", githubUsername: "Testjolonauta5"},{mission: "java", githubUsername: "Testjolonauta6"},{mission: "java", githubUsername: "Testjolonauta7"}];
+        const ExplorerAmount = ExplorerService.getExplorersUsernamesByMission(explorers,"node");  
+        expect(ExplorerAmount[0]).toBe("Testjolonauta1");
+    });
+
+    test ("Requerimiento 4 por stack",()=>{
+        const explorers = [{mission: "node", githubUsername: "Testjolonauta1", name: "Testjolonauta1", stacks:["javascript"]},{mission: "node", githubUsername: "Testjolonauta2", name: "Testjolonauta2", stacks:["javascript"]},{mission: "node", githubUsername: "Testjolonauta3", name: "Testjolonauta3", stacks:["typescript"]},{mission: "java", githubUsername: "Testjolonauta4", name: "Testjolonauta4" , stacks:["spring"]},{mission: "java", githubUsername: "Testjolonauta5", name: "Testjolonauta5", stacks:["spring"]},{mission: "java", githubUsername: "Testjolonauta6", name: "Testjolonauta6", stacks:["spring"]},{mission: "java", githubUsername: "Testjolonauta7", name: "Testjolonauta7", stacks:["spring"]}];
+        const explorerstack = ExplorerService.getExplorerWithStack(explorers, "javascript");
+        expect(explorerstack[0].name).toBe("Testjolonauta1");
+    });
+
 });


### PR DESCRIPTION
Se implemento una nueva ruta para poder encontrar los explorers que contengan en su lista de stacks un stack en especifico, esto atravez de:
* 1 Implementación de un metodo llamado getExplorerWithStack dentro de Explorer service
* 2 Implementación de pruebas unitarias del metodo implementado
* 3 Implementación de un metodo en Explorer controler donde se recupera la lista completa de explorers que será enviada a el getExplorerWithStack() del Explorer service
* 4 Implementaci;ón de pruebas para el metodo implementado en Explorer Controller
* 5 Implementacion de endpoint /v1/explorers/stack/:stack

## Flujo de Nueva funcionalidad

```mermaid
graph TD;
    ExplorerService -->ExplorerController;
    ExplorerController-->Server;
```

```mermaid
graph TD;
   id1["getExplorerWithStack(explorers, stack)"] --> id2["getExplorerWithStack(stack)"];
   id2["getExplorerWithStack(stack)"] --> id3["/v1/explorers/stack/:stack"];
```