### PR TITLE
4 Contribución Open Source

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const result = ExplorerService.getExplorersByStack(explorers,stack);
+        return result;
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,3 +36,9 @@ app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response)=>{
+    const stack = request.params.stack;
+    const explorerInMission = ExplorerController.getExplorersByStack(stack);
+    response.json(explorerInMission);
+});
+

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,6 +15,10 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
+    static getExplorersByStack(explorers,stack){
+        const explorersInNode = explorers.filter((explorer) => explorer.stacks.find((tec)=>tec==stack));
+        return explorersInNode;
+    }
 
 }
 

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,5 +6,23 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
+    test ("For getExplorersByStack function que filtra explorers dependieno de la stack",()=>{
+        const explorers = [{stacks: [
+            "javascript",
+            "elixir",
+            "groovy",
+            "reasonML",
+            "elm"] 
+        },
+        {stacks: [
+            "elixir",
+            "groovy",
+            "reasonML",
+            "elm"] 
+        }
+        ];
+        const explorersInNode = ExplorerService.getExplorersByStack(explorers, "javascript");
+        expect(explorersInNode.length).toBe(1);
+    });
 
 });


### PR DESCRIPTION
Creando un nuevo endpoint que regrese toda la lista de explorers filtrados por un stack.

URL: localhost:3000/v1/explorers/stack/javascript.
Response: Todos los explorers que tengan en stack el valor recibido en la url: javascript. (este valor debe ser dinámico)
Open Source
Pruebas: Cree una lista con dos objetos uno sin stack de js y otro con, y valide el numero de objetos con js en el stacks que deberia ser 1, ya que el dato a filtrar es js.