### PR TITLE
Creación de endpoint lista explorers por stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersbyStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -26,6 +26,12 @@ app.get("/v1/explorers/usernames/:mission", (request, response) => {
     response.json({mission: request.params.mission, explorers: explorersUsernames});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersByStack = ExplorerController.getExplorersByStack(stack);
+    response.json({mission: request.params.mission, explorers: explorersByStack});
+});
+
 app.get("/v1/fizzbuzz/:score", (request, response) => {
     const score = parseInt(request.params.score);
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersbyStack(explorers,stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,5 +6,10 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
-
+    
+    test("Requerimiento 2: Obtener todos los explorers con cierto stack", () => {
+        const explorers = [{stacks: ["javascript","reasonML","elm"]}];
+        const explorersWithStack = ExplorerService.getExplorersbyStack(explorers, "reasonML");
+        expect(explorersWithStack.length).toBe(1);
+    });
 });


### PR DESCRIPTION
## Pull request de Creación de endpoint lista explorers por stack
Creación de un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.

Ejemplo de url: `localhost:3000/v1/explorers/stack/javascript.`
Response: Todos los explorers que tengan en stack el valor recibido en la url.

### Estos son los pasos que seguí para cumplir con el requerimiento:
- Creamos el método estático getExplorersbyStack en el ExplorerService
```
static getExplorersbyStack(explorers,stack){
        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
        return explorersByStack;
}
```
- Creamos el test para el nuevo método de getExplorersbyStack
```
test("Requerimiento 2: Obtener todos los explorers con cierto stack", () => {
        const explorers = [{stacks: ["javascript","reasonML","elm"]}];
        const explorersWithStack = ExplorerService.getExplorersbyStack(explorers, "reasonML");
        expect(explorersWithStack.length).toBe(1);
    });
```
- Creamos el método estático getExplorersByStack en ExplorerController
```
static getExplorersByStack(stack){
        const explorers = Reader.readJsonFile("explorers.json");
        return ExplorerService.getExplorersbyStack(explorers, stack);
    }
```
- Creamos el endpoint /v1/explorers/stack/javascript en la API para obtener los explorers por stack
```
app.get("/v1/explorers/stack/:stack", (request, response) => {
    const stack = request.params.stack;
    const explorersByStack = ExplorerController.getExplorersByStack(stack);
    response.json({mission: request.params.mission, explorers: explorersByStack});
});
```