### PR TITLE
Agregando funcionalidad del nuevo requerimiento para obtener lista de explorers por stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -36,3 +36,8 @@ app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorerStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorerStack);
+});

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static filterByStack(explorers, stack){
+        const explorersByStack = explorers.filter((explorer) => explorer.stacks.includes(stack));
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,5 +6,10 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
+    test("Nuevo Requerimiento: devolver todos los explorers con el stack javascript", () => {
+        const explorers = [{stacks: ["java", "ruby", "javascript"]}, {stacks: ["java", "ruby", "python"]}, {stacks: ["ruby", "rails"]}];
+        const explorersJS = ExplorerService.filterByStack(explorers, "javascript");
+        expect(explorersJS.length).toBe(1);
+    });
 
 });


### PR DESCRIPTION
# Se adjunta solución al requerimiento solicitado: 

 `Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.`

## Cambios

- Se realizó el cambio al `ExplorerService.js` para añadir la funcionalidad de filtrar de la lista de explorers, los explorers que tengan un stack determinado.
- Se añadió una prueba `ExplorerService.test.js` para comprobar la funcionalidad de `ExplorerService.js`.
- Se añadió el método `getExplorersByStack(stack)` al archivo de `ExplorerController.js` que manda un string con el stack solicitado para usar el método de `filterByStack(explorers, stack)` de la clase `ExplorerService.js`.
- Por ultimo se añadió el nuevo Endpoint que mande el stack a través del servidor.

| Endpoint | Request | Response |
|---|---|---|
| `localhost:3000/v1/explorers/stack/:stack` | `localhost:3000/v1/explorers/stack/javascript` | Deberás obtener la lista de explorers en con el Stack que enviaste (javascript) |