### PR TITLE
Contribución: creando endpoint que regresa lista de explorers filtrados por stack

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,10 +10,19 @@ module.exports = {
         "ecmaVersion": "latest"
     },
     "rules": {
-        "no-unused-vars": "off",
-        indent: ["error", 4],
+        indent : ["error", 4],
         "linebreak-style": ["error", "unix"],
         quotes: ["error", "double"],
-        semi: ["error", "always"]
+        semi: ["error", "always"],
+        "multiline-comment-style": ["error", "bare-block"],
+        camelcase: "warn",
+        eqeqeq: ["error", "always"],
+        "func-call-spacing": ["error", "always"],
+        "one-var": ["error", "consecutive"],
+        "no-cond-assign": ["error", "always"],
+        "no-console": "error",
+        "no-extra-parens": "error",
+        "no-constant-condition": "error",
+        "no-dupe-args": "error"
     }
-};
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,9 +20,8 @@ module.exports = {
         "func-call-spacing": ["error", "always"],
         "one-var": ["error", "consecutive"],
         "no-cond-assign": ["error", "always"],
-        "no-console": "error",
         "no-extra-parens": "error",
         "no-constant-condition": "error",
         "no-dupe-args": "error"
     }
-}
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile ("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission (explorers, mission);
     }
+
+    static getExplorersByStack(mission){
+        const explorers = Reader.readJsonFile ("explorers.json");
+        return ExplorerService.getExplorersByStack (explorers, mission);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -1,25 +1,25 @@
-const ExplorerService = require("../services/ExplorerService");
-const FizzbuzzService = require("../services/FizzbuzzService");
-const Reader = require("../utils/reader");
+const ExplorerService = require ("../services/ExplorerService"),
+    FizzbuzzService = require ("../services/FizzbuzzService"),
+    Reader = require ("../utils/reader");
 
 class ExplorerController{
     static getExplorersByMission(mission){
-        const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByMission(explorers, mission);
+        const explorers = Reader.readJsonFile ("explorers.json");
+        return ExplorerService.filterByMission (explorers, mission);
     }
 
     static applyFizzbuzz(score){
-        return FizzbuzzService.applyValidationInNumber(score);
+        return FizzbuzzService.applyValidationInNumber (score);
     }
 
     static getExplorersUsernamesByMission(mission){
-        const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.getExplorersUsernamesByMission(explorers, mission);
+        const explorers = Reader.readJsonFile ("explorers.json");
+        return ExplorerService.getExplorersUsernamesByMission (explorers, mission);
     }
 
     static getExplorersAmonutByMission(mission){
-        const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
+        const explorers = Reader.readJsonFile ("explorers.json");
+        return ExplorerService.getAmountOfExplorersByMission (explorers, mission);
     }
 }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,14 @@ app.get ("/v1/fizzbuzz/:score", (request, response) => {
     response.json ({score: score, trick: fizzbuzzTrick});
 });
 
-app.listen (port, () => {
+app.get ("/v1/explorers/stack/:technology", (request, response) => {
+    const technology = request.params.technology,
+        javascriṕtStackExplorers = ExplorerController.getExplorersByStack (technology);
+    response.json ({technology: technology, explorers: javascriṕtStackExplorers});
+});
+
+const server = app.listen (port, () => {
     console.log (`FizzBuzz API in localhost:${port}`);
 });
 
+module.exports = {app, server};

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,38 +1,38 @@
-const ExplorerController = require("./controllers/ExplorerController");
-const express = require("express");
-const app = express();
-app.use(express.json());
+const ExplorerController = require ("./controllers/ExplorerController"),
+    express = require ("express");
+const app = express ();
+app.use (express.json ());
 const port = 3000;
 
-app.get("/", (request, response) => {
-    response.json({message: "FizzBuzz Api welcome!"});
+app.get ("/", (request, response) => {
+    response.json ({message: "FizzBuzz Api welcome!"});
 });
 
-app.get("/v1/explorers/:mission", (request, response) => {
-    const mission = request.params.mission;
-    const explorersInMission = ExplorerController.getExplorersByMission(mission);
-    response.json(explorersInMission);
+app.get ("/v1/explorers/:mission", (request, response) => {
+    const mission = request.params.mission,
+        explorersInMission = ExplorerController.getExplorersByMission (mission);
+    response.json (explorersInMission);
 });
 
-app.get("/v1/explorers/amount/:mission", (request, response) => {
-    const mission = request.params.mission;
-    const explorersAmountInMission = ExplorerController.getExplorersAmonutByMission(mission);
-    response.json({mission: request.params.mission, quantity: explorersAmountInMission});
+app.get ("/v1/explorers/amount/:mission", (request, response) => {
+    const mission = request.params.mission,
+        explorersAmountInMission = ExplorerController.getExplorersAmonutByMission (mission);
+    response.json ({mission: request.params.mission, quantity: explorersAmountInMission});
 });
 
-app.get("/v1/explorers/usernames/:mission", (request, response) => {
-    const mission = request.params.mission;
-    const explorersUsernames = ExplorerController.getExplorersUsernamesByMission(mission);
-    response.json({mission: request.params.mission, explorers: explorersUsernames});
+app.get ("/v1/explorers/usernames/:mission", (request, response) => {
+    const mission = request.params.mission,
+        explorersUsernames = ExplorerController.getExplorersUsernamesByMission (mission);
+    response.json ({mission: request.params.mission, explorers: explorersUsernames});
 });
 
-app.get("/v1/fizzbuzz/:score", (request, response) => {
-    const score = parseInt(request.params.score);
-    const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
-    response.json({score: score, trick: fizzbuzzTrick});
+app.get ("/v1/fizzbuzz/:score", (request, response) => {
+    const score = parseInt (request.params.score),
+        fizzbuzzTrick = ExplorerController.applyFizzbuzz (score);
+    response.json ({score: score, trick: fizzbuzzTrick});
 });
 
-app.listen(port, () => {
-    console.log(`FizzBuzz API in localhost:${port}`);
+app.listen (port, () => {
+    console.log (`FizzBuzz API in localhost:${port}`);
 });
 

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -1,19 +1,24 @@
 class ExplorerService {
 
     static filterByMission(explorers, mission){
-        const explorersByMission = explorers.filter((explorer) => explorer.mission == mission);
+        const explorersByMission = explorers.filter ((explorer) => explorer.mission === mission);
         return explorersByMission;
     }
 
     static getAmountOfExplorersByMission(explorers, mission){
-        const explorersByMission = ExplorerService.filterByMission(explorers, mission);
+        const explorersByMission = ExplorerService.filterByMission (explorers, mission);
         return explorersByMission.length;
     }
 
     static getExplorersUsernamesByMission(explorers, mission){
-        const explorersByMission = ExplorerService.filterByMission(explorers, mission);
-        const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
+        const explorersByMission = ExplorerService.filterByMission (explorers, mission),
+            explorersUsernames = explorersByMission.map ((explorer) => explorer.githubUsername);
         return explorersUsernames;
+    }
+
+    static getExplorersByStack(explorers, mission){
+        const explorersByStackLanguage = explorers.filter ( explorer => explorer.stacks.includes (mission));
+        return explorersByStackLanguage;
     }
 
 }

--- a/lib/utils/reader.js
+++ b/lib/utils/reader.js
@@ -1,9 +1,9 @@
-const fs = require("fs");
+const fs = require ("fs");
 
 class Reader{
     static readJsonFile(path){
-        const rawdata = fs.readFileSync(path);
-        return JSON.parse(rawdata);
+        const rawdata = fs.readFileSync (path);
+        return JSON.parse (rawdata);
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "eslint": "^8.14.0",
-        "jest": "^27.5.1"
+        "jest": "^27.5.1",
+        "supertest": "^6.2.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1239,6 +1240,12 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -1456,6 +1463,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1584,6 +1604,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1649,6 +1675,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1775,6 +1807,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2333,6 +2375,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -2442,6 +2490,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formidable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
+      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "1.0.3",
+        "hexoid": "1.0.0",
+        "once": "1.4.0",
+        "qs": "6.9.3"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/formidable/node_modules/qs": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -2506,6 +2581,20 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-package-type": {
@@ -2592,6 +2681,27 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true,
       "engines": {
         "node": ">=8"
@@ -3906,6 +4016,15 @@
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
+    "node_modules/object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -4229,6 +4348,20 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -4425,6 +4558,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -4490,6 +4637,35 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -4558,6 +4734,97 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.3.tgz",
+      "integrity": "sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
+        "methods": "^1.1.2",
+        "mime": "^2.5.0",
+        "qs": "^6.10.3",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/qs": {
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.2.3.tgz",
+      "integrity": "sha512-3GSdMYTMItzsSYjnIcljxMVZKPW1J9kYHZY+7yLfD0wpPwww97GeImZC1oOk0S5+wYl2niJwuFusBJqwLqYM3g==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -4785,6 +5052,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -6000,6 +6273,12 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -6173,6 +6452,16 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -6266,6 +6555,12 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "component-emitter": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6310,6 +6605,12 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.3.tgz",
+      "integrity": "sha512-JxbCBUdrfr6AQjOXrxoTvAMJO4HBTUIlBzslcJPAz+/KT8yk53fXun51u+RenNYvad/+Vc2DIz5o9UxlCDymFQ==",
+      "dev": true
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -6410,6 +6711,16 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "dezalgo": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+      "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff-sequences": {
       "version": "27.5.1",
@@ -6825,6 +7136,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "fb-watchman": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
@@ -6918,6 +7235,26 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formidable": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.0.1.tgz",
+      "integrity": "sha512-rjTMNbp2BpfQShhFbR3Ruk3qk2y9jKpvMW78nJgx8QKtxjDVrwbZG+wvDOmVbifHyOUOQJXxqEy6r0faRrPzTQ==",
+      "dev": true,
+      "requires": {
+        "dezalgo": "1.0.3",
+        "hexoid": "1.0.0",
+        "once": "1.4.0",
+        "qs": "6.9.3"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.9.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
+          "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==",
+          "dev": true
+        }
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -6964,6 +7301,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -7025,6 +7373,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "hexoid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-1.0.0.tgz",
+      "integrity": "sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==",
       "dev": true
     },
     "html-encoding-sniffer": {
@@ -8033,6 +8393,12 @@
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
       "dev": true
     },
+    "object-inspect": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -8268,6 +8634,17 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -8420,6 +8797,17 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      }
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8474,6 +8862,23 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true
+        }
+      }
+    },
     "string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -8521,6 +8926,72 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "superagent": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-7.1.3.tgz",
+      "integrity": "sha512-WA6et4nAvgBCS73lJvv1D0ssI5uk5Gh+TGN/kNe+B608EtcVs/yzfl+OLXTzDs7tOBDIpvgh/WUs1K2OK1zTeQ==",
+      "dev": true,
+      "requires": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.3",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.0.1",
+        "methods": "^1.1.2",
+        "mime": "^2.5.0",
+        "qs": "^6.10.3",
+        "readable-stream": "^3.6.0",
+        "semver": "^7.3.7"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "mime": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "dev": true,
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
+    "supertest": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.2.3.tgz",
+      "integrity": "sha512-3GSdMYTMItzsSYjnIcljxMVZKPW1J9kYHZY+7yLfD0wpPwww97GeImZC1oOk0S5+wYl2niJwuFusBJqwLqYM3g==",
+      "dev": true,
+      "requires": {
+        "methods": "^1.1.2",
+        "superagent": "^7.1.3"
+      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -8690,6 +9161,12 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,17 +4,18 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
+    "server": "node ./lib/server.js",
+    "test": "node ./node_modules/.bin/jest --forceExit --maxWorkers=1 --detectOpenHandles",
     "linter": "node ./node_modules/eslint/bin/eslint.js",
-    "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
-    "server": "node ./lib/server.js"
+    "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
     "eslint": "^8.14.0",
-    "jest": "^27.5.1"
+    "jest": "^27.5.1",
+    "supertest": "^6.2.3"
   },
   "dependencies": {
     "express": "^4.17.3"

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,62 @@
+const ExplorerController = require ("../../lib/controllers/ExplorerController");
+
+describe ("Tests's suite for Explorer Controller", () => {
+    test ("1) Getting a list of explorers in Node", () => {
+        const getExplorers = ExplorerController.getExplorersByMission ("node");
+        expect (getExplorers.length).toBe (10);
+    });
+
+    test ("2) Testing fizzBuzz method", () => {
+        const getFizzbuzzResultDivByThree = ExplorerController.applyFizzbuzz (6),
+            getFizzbuzzResultDivByFive = ExplorerController.applyFizzbuzz (10),
+            getFizzbuzzResultDivByThreeAndFive = ExplorerController.applyFizzbuzz (30),
+            getFizzbuzzResultNonDiv = ExplorerController.applyFizzbuzz (14);
+
+        expect (getFizzbuzzResultDivByThree).toBe ("FIZZ");
+        expect (getFizzbuzzResultDivByFive).toBe ("BUZZ");
+        expect (getFizzbuzzResultDivByThreeAndFive).toBe ("FIZZBUZZ");
+        expect (getFizzbuzzResultNonDiv).toBe (14);
+    });
+
+    test ("3) Testing getExplorersUsernamesByMission method", () => {
+        const getExplorersUsernamesInJava = ExplorerController.getExplorersUsernamesByMission ("java"),
+            getExplorersUsernamesInNode = ExplorerController.getExplorersUsernamesByMission ("node"),
+            expectedJava = ["ajolonauta6", "ajolonauta7", "ajolonauta8", "ajolonauta9", "ajolonauta10"],
+            expectedNode = ["ajolonauta1", "ajolonauta2", "ajolonauta3", "ajolonauta4", "ajolonauta5", "ajolonauta11", "ajolonauta12", "ajolonauta13", "ajolonauta14", "ajolonauta15"];
+
+        expect (getExplorersUsernamesInJava).toEqual (expect.arrayContaining (expectedJava));
+        expect (getExplorersUsernamesInNode).toEqual (expect.arrayContaining (expectedNode));
+    });
+
+    test ("4) Testing getExplorersAmonutByMission method", () => {
+        const explorersAmountInNode = ExplorerController.getExplorersAmonutByMission ("node"),
+            explorersAmountInJava = ExplorerController.getExplorersAmonutByMission ("java");
+
+        expect (explorersAmountInNode).toBe (10);
+        expect (explorersAmountInJava).toBe (5);
+    });
+
+    test ("5) Testing getExplorersByStack method", () => {
+        const explorersByJavaScriptStack = ExplorerController.getExplorersByStack ("javascript"),
+            expected = [
+                { "name": "Woopa1", "githubUsername": "ajolonauta1", "score": 1, "mission": "node", 
+                    "stacks": [ "javascript", "reasonML", "elm"] },
+                { "name": "Woopa2", "githubUsername": "ajolonauta2", "score": 2, "mission": "node", 
+                    "stacks": [ "javascript", "groovy", "elm"] },
+                { "name": "Woopa4", "githubUsername": "ajolonauta4", "mission": "node", "score": 4, 
+                    "stacks": [ "javascript"] },
+                { "name": "Woopa5", "githubUsername": "ajolonauta5", "score": 5, "mission": "node", 
+                    "stacks": [ "javascript", "elixir", "elm" ] },
+                { "name": "Woopa9", "githubUsername": "ajolonauta9", "score": 9, "mission": "java", 
+                    "stacks": [ "javascript", "elixir", "groovy", "reasonML", "elm" ]},
+                { "name": "Woopa10", "githubUsername": "ajolonauta10", "score": 10, "mission": "java","stacks": [ "javascript", "elixir", "groovy", "reasonML", "elm" ]},
+                { "name": "Woopa11", "githubUsername": "ajolonauta11", "score": 11, "mission": "node","stacks": [ "javascript", "elixir", "groovy", "reasonML", "elm" ]},
+                { "name": "Woopa12", "githubUsername": "ajolonauta12", "score": 12, "mission": "node","stacks": [ "javascript", "elixir", "groovy", "reasonML", "elm" ]},
+                { "name": "Woopa13", "githubUsername": "ajolonauta13", "score": 13, "mission": "node","stacks": [ "javascript", "elixir", "groovy", "reasonML", "elm" ]},
+                { "name": "Woopa14", "githubUsername": "ajolonauta14", "score": 14, "mission": "node","stacks": [ "javascript", "elixir", "groovy", "reasonML", "elm" ]},
+                { "name": "Woopa15", "githubUsername": "ajolonauta15", "score": 15, "mission": "node",      "stacks": [ "javascript", "elixir", "groovy", "reasonML", "elm" ]}
+            ];
+
+        expect (explorersByJavaScriptStack).toEqual (expect.arrayContaining (expected));
+    });
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,50 @@
+const request = require ("supertest"),
+    {app, server} = require ("../lib/server");
+
+describe ("Test's suite for API", () => {
+    test ("Test if endpoint GET /v1/explorers/:mission returns a list with explorers", async () => {
+        const response = await request (app).get ("/v1/explorers/node").send ();
+        expect (response._body.length).toBe (10);
+    });
+
+    test ("Getting amount of explorers in Java GET /v1/explorers/amount/:mission", async () => {
+        const response = await request (app).get ("/v1/explorers/amount/java").send ();
+        expect (response._body.quantity).toBe (5);
+    });
+
+    test ("Checking if the response of GET /v1/explorers/usernames/node has the usernames of 10 explorers", async () => {
+        const githubUsernamesOfNodeExplorers = ["ajolonauta1", "ajolonauta2", "ajolonauta3", "ajolonauta4", "ajolonauta5", "ajolonauta11", "ajolonauta12", "ajolonauta13", "ajolonauta14", "ajolonauta15"],
+            response = await request (app).get ("/v1/explorers/usernames/node").send ();
+        expect (response._body.explorers).toEqual (expect.arrayContaining (githubUsernamesOfNodeExplorers));
+    });
+
+    test ("Testing endpoint /v1/fizzbuzz/:score", async () => {
+        const responseFizz = await request (app).get ("/v1/fizzbuzz/3").send (),
+            responseBuzz = await request (app).get ("/v1/fizzbuzz/5").send (),
+            responseFizzBuzz = await request (app).get ("/v1/fizzbuzz/15").send (),
+            responseNonFizzBuzz = await request (app).get ("/v1/fizzbuzz/7").send ();
+        
+        expect (responseFizz._body.trick).toBe ("FIZZ");
+        expect (responseBuzz._body.trick).toBe ("BUZZ");
+        expect (responseFizzBuzz._body.trick).toBe ("FIZZBUZZ");
+        expect (responseNonFizzBuzz._body.trick).toBe (7);
+    });
+
+    test ("Testing endpoint /v1/explorers/stack/:technology", async () => {
+        const expected = [{"name": "Woopa1"}, {"name": "Woopa2"}, {"name": "Woopa4"}, {"name": "Woopa5"}, {"name": "Woopa9"}, 
+                {"name": "Woopa10"}, {"name": "Woopa11"}, {"name": "Woopa12"}, {"name": "Woopa13"}, {"name": "Woopa14"}, {"name": "Woopa15"}],
+            javascriptStackExplorers = await request (app).get ("/v1/explorers/stack/javascript").send (),
+            result = javascriptStackExplorers._body.explorers;
+
+        for(let explorer = 0; explorer < result.length; explorer++){
+            expect (result[explorer].name).toBe (expected[explorer].name);
+        }
+
+        expect (result.length).not.toBe (0);
+
+    });
+});
+
+afterAll ( () => {
+    server.close ();
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,10 +1,36 @@
-const ExplorerService = require("./../../lib/services/ExplorerService");
+const ExplorerService = require ("./../../lib/services/ExplorerService");
 
-describe("Tests para ExplorerService", () => {
-    test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
-        const explorers = [{mission: "node"}];
-        const explorersInNode = ExplorerService.filterByMission(explorers, "node");
-        expect(explorersInNode.length).toBe(1);
+describe ("Tests para ExplorerService", () => {
+    test ("Requerimiento 1: Calcular todos los explorers en una misión", () => {
+        const explorers = [{mission: "node"}, {mission: "node"}, {mission: "java"}], 
+            explorersInNode = ExplorerService.filterByMission (explorers, "node");
+        expect (explorersInNode.length).toBe (2);
+    });
+
+    test ("Requerimiento 2: Verificar que todos los exṕlorers se encuentren en una misma misión", () => {
+        const explorers = [{mission: "java"}, {mission: "java"}, {mission: "java"}],
+            explorersInJava = ExplorerService.getAmountOfExplorersByMission (explorers, "java");
+        expect (explorersInJava) . toBe (3);
+    });
+
+    test ("Requerimiento 3: Verificar que se regrese una lista de explorers filtrados por username", () => {
+        const explorers = [{mission: "node", githubUsername: "ajolonauta1"}, 
+                {mission: "node", githubUsername: "ajolonauta5"}, 
+                {mission: "node", githubUsername: "ajolonauta12"}],
+            expected = ["ajolonauta1", "ajolonauta5", "ajolonauta12"],
+            nodeExplorersUsernames = ExplorerService.getExplorersUsernamesByMission (explorers, "node");
+        expect (nodeExplorersUsernames).toEqual (expect.arrayContaining (expected));
+    });
+
+    //Contribución
+    test ("Requerimiento de contribución: comprobar que se regrese una lista filtrada por stack", () => {
+        const explorers = [{"stacks" : ["javascript", "reasonML", "elm"]}, 
+                {"stacks" : ["javascript", "groovy", "elm"]}, 
+                {"stacks" : ["elixir", "groovy", "reasonML"]}],
+            expected = [{"stacks" : ["javascript", "reasonML", "elm"]}, 
+                {"stacks" : ["javascript", "groovy", "elm"]}],
+            explorersWithStackJS = ExplorerService.getExplorersByStack (explorers, "javascript");
+        expect (explorersWithStackJS).toEqual (expect.arrayContaining (expected));
     });
 
 });


### PR DESCRIPTION
# Contribución Open Source 

Se agregó un nuevo endpoint con la url ```localhost:3000/v1/explorers/stack/javascript``` que regresará un arreglo con los explorers que tengan **javascript** dentro del mismo.

Para esta pequeña contribución, se realizó lo siguiente: 

1. Se instalaron las siguientes dependencias necesarias que permitieran darle funcionalidad:
    - Jest
    - Supertest
    - Linter
    - Express
  
![code1](https://user-images.githubusercontent.com/99224109/168735226-31e51df0-8cf3-44f2-b872-592e7bb74ed3.png)

2. Se designó dentro de las responsabilidades del servicio de ```/lib/services/ExplorerService.js``` un método denominado ```getExplorersByStack(explorers, mission)``` que regresa dicha lista filtrada por stack.  *(Tests incluídos en ```test/services/ExplorerService.test.js``` para corroborar funcionalidad de código legado).*

![code2](https://user-images.githubusercontent.com/99224109/168736077-b186678b-b066-472e-bb23-8c9ef7603f05.png)

3. Se implementó el método de ```getExplorersByStack(mission)``` en el controlador ```lib/controllers/ExplorerController.js``` extendiendo la funcionalidad de la clase.  *(Tests incluídos en ```test/controllers/ExplorerController.test.js```) para corroborar funcionalidad de código legado.*

![code3](https://user-images.githubusercontent.com/99224109/168736879-c7a3df84-c55e-49a3-a473-6dd2b6b92cf9.png)

4. Finalmente se implementó el endpoint ya descrito en ```lib/server.js```, regresando un objeto con la tecnología y los explorers resultantes por stack. *(Tests incluídos en ```test/controllers/ExplorerController.test.js```) para corroborar funcionalidad de endpoints legados e implementado.*

![server](https://user-images.githubusercontent.com/99224109/168737543-978ff8fe-ec17-4aef-89c6-f50bd1f9dad7.png)

