### PR TITLE
Nuevo Endpoint que muestra una lista de explorers según su Stack

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,14 +3,13 @@ module.exports = {
         "browser": true,
         "commonjs": true,
         "es2021": true,
-        "jest": true
+        "jest":true
     },
     "extends": "eslint:recommended",
     "parserOptions": {
         "ecmaVersion": "latest"
     },
     "rules": {
-        "no-unused-vars": "off",
         indent: ["error", 4],
         "linebreak-style": ["error", "unix"],
         quotes: ["error", "double"],

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,33 @@
-name: Run Tests in my project every push on GitHub
-
-on: [push, pull_request]
-
+name: Jest
+on: push
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Run Jest
-      uses: stefanoeb/jest-action@1.0.3
+      - uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: "12"
+
+      # Speed up subsequent runs with caching
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      # Install required deps for action
+      - name: Install Dependencies
+        run: npm install
+
+      # Finally, run our tests
+      - name: Run the tests
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+*.json
+!package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,10 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.filterByStack(explorers,stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,7 +31,11 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
     response.json({score: score, trick: fizzbuzzTrick});
 });
-
+app.get("/v1/explorers/stack/:mission", (request, response) => {
+    const mission = request.params.mission;
+    const usersTrick = ExplorerController.getExplorersByStack(mission);
+    response.json(usersTrick);
+});
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,8 +15,8 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
-    static filterByStack(explorers,stack){
-        const explorersByStack = explorers.filter((explorer)=>explorer.stack.includes(stack));
+    static filterByStack(explorers,stacks){
+        const explorersByStack = explorers.filter((explorer)=>explorer.stacks.includes(stacks));
         return explorersByStack
     }
 

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,6 +15,10 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
+    static filterByStack(explorers,stack){
+        const explorersByStack = explorers.filter((explorer)=>explorer.stack.includes(stack));
+        return explorersByStack
+    }
 
 }
 

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -17,7 +17,7 @@ class ExplorerService {
     }
     static filterByStack(explorers,stacks){
         const explorersByStack = explorers.filter((explorer)=>explorer.stacks.includes(stacks));
-        return explorersByStack
+        return explorersByStack;
     }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "express": "^4.17.3"
       },
       "devDependencies": {
-        "eslint": "^8.14.0",
+        "eslint": "^8.15.0",
         "jest": "^27.5.1"
       }
     },
@@ -567,19 +567,19 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
+      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "globals": "^13.9.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -593,9 +593,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1094,9 +1094,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1911,12 +1911,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -1927,7 +1927,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -1943,7 +1943,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -2120,13 +2120,13 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -5451,19 +5451,19 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
-      "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.3.tgz",
+      "integrity": "sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "globals": "^13.9.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
@@ -5474,9 +5474,9 @@
           "dev": true
         },
         "globals": {
-          "version": "13.13.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+          "version": "13.15.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
+          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -5895,9 +5895,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
       "dev": true
     },
     "acorn-globals": {
@@ -6511,12 +6511,12 @@
       }
     },
     "eslint": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
-      "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.15.0.tgz",
+      "integrity": "sha512-GG5USZ1jhCu8HJkzGgeK8/+RGnHaNYZGrGDzUtigK3BsGESW/rs2az23XqE0WVwDxy1VRvvjSSGu5nB0Bu+6SA==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.2",
+        "@eslint/eslintrc": "^1.2.3",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -6527,7 +6527,7 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.3.2",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -6543,7 +6543,7 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
@@ -6664,13 +6664,13 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
-      "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.2.tgz",
+      "integrity": "sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.7.1",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "fizzbuzz",
   "version": "1.0.0",
-  "description": "",
+  "description": "1. Instalar dependencia:",
   "main": "index.js",
   "scripts": {
-    "test": "node ./node_modules/.bin/jest",
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest",
     "linter": "node ./node_modules/eslint/bin/eslint.js",
     "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
     "server": "node ./lib/server.js"
@@ -18,5 +18,17 @@
   },
   "dependencies": {
     "express": "^4.17.3"
-  }
+  },
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/MoisesMendozaS01/fizzbuzz.git"
+  },
+  "bugs": {
+    "url": "https://github.com/MoisesMendozaS01/fizzbuzz/issues"
+  },
+  "homepage": "https://github.com/MoisesMendozaS01/fizzbuzz#readme"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "eslint": "^8.14.0",
+    "eslint": "^8.15.0",
     "jest": "^27.5.1"
   },
   "dependencies": {

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,10 +1,9 @@
-const { TestWatcher } = require('jest');
-const ExplorerController = require('./../../../fizzbuzz/lib/controllers/ExplorerController');
+const ExplorerController = require("./../../../fizzbuzz/lib/controllers/ExplorerController");
 
-describe('Unit Test for ExplorerController',()=>{
-    test('Parte 1:Prueba de unidad para llamar la funcion filtrar por stack',()=>{
-        const ExplorersInNodeJavascript = ExplorerController.getExplorersByStack('javascript');
+describe("Unit Test for ExplorerController",()=>{
+    test("Parte 1:Prueba de unidad para llamar la funcion filtrar por stack",()=>{
+        const ExplorersInNodeJavascript = ExplorerController.getExplorersByStack("javascript");
 
         expect(ExplorersInNodeJavascript).not.toBeUndefined();
     });
-})
+});

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,10 @@
+const { TestWatcher } = require('jest');
+const ExplorerController = require('./../../../fizzbuzz/lib/controllers/ExplorerController');
+
+describe('Unit Test for ExplorerController',()=>{
+    test('Parte 1:Prueba de unidad para llamar la funcion filtrar por stack',()=>{
+        const ExplorersInNodeJavascript = ExplorerController.getExplorersByStack('javascript');
+
+        expect(ExplorersInNodeJavascript).not.toBeUndefined();
+    });
+})

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,7 +7,7 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
     test('Requerimiento 2: Mostrar todos los explorers por stack',()=>{
-        const explorers = [{name:'ajolote1',stack:['node','java']},{name:'ajolote2',stack:['node','java']},{name:'ajolote3',stack:'node'},{name:'ajolote4',stack:'java'}];
+        const explorers = [{name:'ajolote1',stacks:['node','java']},{name:'ajolote2',stacks:['node','java']},{name:'ajolote3',stacks:'node'},{name:'ajolote4',stacks:'java'}];
         const explorerInNode = ExplorerService.filterByStack(explorers,'node');
         expect(explorerInNode).not.toBeUndefined()
     })

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,10 +6,10 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
-    test('Requerimiento 2: Mostrar todos los explorers por stack',()=>{
-        const explorers = [{name:'ajolote1',stacks:['node','java']},{name:'ajolote2',stacks:['node','java']},{name:'ajolote3',stacks:'node'},{name:'ajolote4',stacks:'java'}];
-        const explorerInNode = ExplorerService.filterByStack(explorers,'node');
-        expect(explorerInNode).not.toBeUndefined()
-    })
+    test("Requerimiento 2: Mostrar todos los explorers por stack",()=>{
+        const explorers = [{name:"ajolote1",stacks:["node","java"]},{name:"ajolote2",stacks:["node","java"]},{name:"ajolote3",stacks:"node"},{name:"ajolote4",stacks:"java"}];
+        const explorerInNode = ExplorerService.filterByStack(explorers,"node");
+        expect(explorerInNode).not.toBeUndefined();
+    });
 
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -6,5 +6,10 @@ describe("Tests para ExplorerService", () => {
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
     });
+    test('Requerimiento 2: Mostrar todos los explorers por stack',()=>{
+        const explorers = [{name:'ajolote1',stack:['node','java']},{name:'ajolote2',stack:['node','java']},{name:'ajolote3',stack:'node'},{name:'ajolote4',stack:'java'}];
+        const explorerInNode = ExplorerService.filterByStack(explorers,'node');
+        expect(explorerInNode.name).toContain('ajolote1')
+    })
 
 });

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -9,7 +9,7 @@ describe("Tests para ExplorerService", () => {
     test('Requerimiento 2: Mostrar todos los explorers por stack',()=>{
         const explorers = [{name:'ajolote1',stack:['node','java']},{name:'ajolote2',stack:['node','java']},{name:'ajolote3',stack:'node'},{name:'ajolote4',stack:'java'}];
         const explorerInNode = ExplorerService.filterByStack(explorers,'node');
-        expect(explorerInNode.name).toContain('ajolote1')
+        expect(explorerInNode).not.toBeUndefined()
     })
 
 });


### PR DESCRIPTION
## Contribución Open Source

Requerimiento:

Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.
`localhost:3000/v1/explorers/stack/javascript`.
Response: Todos los explorers que tengan en stack el valor recibido en la url: javascript. (este valor debe ser dinámico)
1. Se agrego una función en la clase ExplorerService para filtrar los explorers por Stack, la función recibe dos valores, el primero es una lista de los explorers mientras el segundo valor es el Stack para filtrar.
1.1 Primero se creó una prueba de unidad de la función `./test/services/ExplorerService.test.js`.
![code](https://user-images.githubusercontent.com/99106228/169205732-7a38c1ec-bae4-4355-bd7c-527e724a3ccc.png)

1.2 Se crea el método `filterByStack` en la clase ExplorerService `./lib/services/ExplorerServices.js`.
![code1](https://user-images.githubusercontent.com/99106228/169205817-67095b3f-d8fc-447d-aef9-f3c70441afdc.png)

2. Se implementa el método `getExplorersByStack` en la clase ExplorerController para usar la clase anterior.
2.1 Se crea la prueba de unidad para la función `getExplorersByStack` en el archivo `./test/ExplorerController.test.js`.
![code3](https://user-images.githubusercontent.com/99106228/169207609-5f7c4949-642b-4b1d-9a57-3718f2feb09e.png)
2.2 Se Agrega la función `getExplorersByStack` en la clase `ExplorerController.js`
![code4](https://user-images.githubusercontent.com/99106228/169210429-54131921-d53b-4817-8c6a-f7fd751af58d.png)

3. Se crea el EndPoint  `/v1/explorers/stack/:mission` el cual recibe el nombre del stack para filtrar y llama a la función `getExplorersByStack`.
![code5](https://user-images.githubusercontent.com/99106228/169210967-5c3d2838-74a9-46b6-a483-50cf124b64b4.png).
4. Finalmente se realizan las correcciones de texto con la dependencia linter para tener mejor presentación en el código


 

