### PR TITLE
Nuevo requerimiento donde ser regresa una lista filtrada de explorers por stack 

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,12 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+    const stack = request.params.stack;
+    const explorersInStack = ExplorerController.getExplorersByStack(stack);
+    response.json(explorersInStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,11 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+    static getExplorersByStack(explorers, stack){
+        const explorersByStack = explorers.filter(explorer => explorer.stacks.join(", ").includes(stack));
+        return explorersByStack;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,40 @@
+const ExplorerController = require("../../lib/controllers/ExplorerController");
+
+describe("Unit Tests for ExplorerService class", () => {
+    test("1) Use the method getExplorersByMission()", () => {
+        const explorersInNodeMission = ExplorerController.getExplorersByMission("node");
+
+        explorersInNodeMission.forEach(explorer => {
+            expect(explorer.mission).toBe("node");
+        });
+    });
+
+    test("2) Use the method getExplorersUsernamesByMission()jet", () => {
+        const explorersInNodeMission = ExplorerController.getExplorersUsernamesByMission("node");
+
+        expect(explorersInNodeMission).toEqual(["ajolonauta1", "ajolonauta2", "ajolonauta3", "ajolonauta4", "ajolonauta5",
+            "ajolonauta11", "ajolonauta12", "ajolonauta13", "ajolonauta14", "ajolonauta15"]);
+    });
+
+    test("3) Use the method getExplorersAmonutByMission()", () => {
+        const explorersInNodeMission = ExplorerController.getExplorersAmonutByMission("node");
+        expect(explorersInNodeMission).toEqual(10);
+    });
+
+    test("4) Use the method getValidationInNumber()", () => {
+        expect(ExplorerController.applyFizzbuzz(1)).toEqual(1);
+        expect(ExplorerController.applyFizzbuzz(3)).toBe("FIZZ");
+        expect(ExplorerController.applyFizzbuzz(5)).toBe("BUZZ");
+        expect(ExplorerController.applyFizzbuzz(15)).toBe("FIZZBUZZ");
+
+
+    });
+    test("Requerimiento 4: Lista de explorers filtrados por un stack", () => {
+        const explorersListWithJsStack = ExplorerController.getExplorersByStack("javascript");
+
+        expect(explorersListWithJsStack).toHaveLength(11);
+        expect(explorersListWithJsStack[0].stacks).toEqual(expect.arrayContaining(["javascript"]));
+        expect(explorersListWithJsStack[1].stacks).toEqual(expect.arrayContaining(["javascript"]));
+    });
+    
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -2,9 +2,23 @@ const ExplorerService = require("./../../lib/services/ExplorerService");
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
-        const explorers = [{mission: "node"}];
+        const explorers = [{ mission: "node" }];
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
+    });
+
+    test("Requerimiento 4: Lista de explorers filtrados por un stack", () => {
+        const explorers =
+            [
+                { "name": "Woopa1", "mission": "node", "stacks": ["javascript", "reasonML", "elm"] },
+                { "name": "Woopa2", "mission": "node", "stacks": ["javascript", "groovy", "elm"] },
+                { "name": "Woopa3", "mission": "java", "stacks": ["elixir", "groovy", "reasonML"] }
+            ];
+        const explorersListWithJsStack = ExplorerService.getExplorersByStack(explorers, "javascript");
+
+        expect(explorersListWithJsStack).toHaveLength(2);
+        expect(explorersListWithJsStack[0].stacks).toEqual(expect.arrayContaining(["javascript"]));
+        expect(explorersListWithJsStack[1].stacks).toEqual(expect.arrayContaining(["javascript"]));
     });
 
 });


### PR DESCRIPTION
# Nuevo requerimiento 
### Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.
Se agrego un nuevo método en las clases ExplorerService y ExplorerController, el método getExplorersByStack(stack), el cual te devuelve una lista de todos los explores cuyos stacks incluya el stack pasado en el parámetro. 
Este método he construyo con TDD y respeta la separación de responsabilidades del proyecto.