### PR TITLE
Pull request 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-node_modules
+**node_modules
+**package.json

--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,10 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+    static getExplorersByStack(stack){
+        const explorers = Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers, stack);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -31,7 +31,11 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
     response.json({score: score, trick: fizzbuzzTrick});
 });
-
+app.get("/v1/explorers/stack/:stack", (request, response)=>{
+    const stack = request.params.stack;
+    const filtered = ExplorerController.getExplorersByStack(stack);
+    response.json(filtered);
+});
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -22,6 +22,13 @@ class ExplorerService {
         });
         return explorersWithStack;
     }
+    // static getExplorersByStack(explorers, stack) {
+    //     if (stack) {
+    //         return explorers.filter((i) => {
+    //             return i.stacks.indexOf(stack) >= 0;
+    //         });
+    //     }
+    // }
 }
 
 

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,7 +15,14 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
-
+    static getExplorersByStack(explorers, stack){
+        const explorersWithStack = explorers.filter((explorer) => {
+            if(explorer.stacks.includes(stack))
+                return explorer;
+        });
+        return explorersWithStack;
+    }
 }
+
 
 module.exports = ExplorerService;

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -22,13 +22,6 @@ class ExplorerService {
         });
         return explorersWithStack;
     }
-    // static getExplorersByStack(explorers, stack) {
-    //     if (stack) {
-    //         return explorers.filter((i) => {
-    //             return i.stacks.indexOf(stack) >= 0;
-    //         });
-    //     }
-    // }
 }
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.17.3"
+        "express": "^4.17.3",
+        "lodash": "^4.17.21"
       },
       "devDependencies": {
         "eslint": "^8.14.0",
@@ -3711,8 +3712,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -7883,8 +7883,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -1,10 +1,26 @@
+const Reader = require("../../lib/utils/reader");
 const ExplorerService = require("./../../lib/services/ExplorerService");
+const explorers = Reader.readJsonFile("explorers.json");
 
 describe("Tests para ExplorerService", () => {
     test("Requerimiento 1: Calcular todos los explorers en una misión", () => {
         const explorers = [{mission: "node"}];
         const explorersInNode = ExplorerService.filterByMission(explorers, "node");
         expect(explorersInNode.length).toBe(1);
+    });
+    test("2. Filtrar los explorers por stack", ()=>{
+        const explorers = Reader.readJsonFile("explorers.json");
+        const filter = ExplorerService.getExplorersByStack(explorers, "javascript");
+        const filter1 = ExplorerService.getExplorersByStack(explorers, "elm");
+        const filter2 = ExplorerService.getExplorersByStack(explorers, "groovy");
+        const filter3 = ExplorerService.getExplorersByStack(explorers, "reasonML");
+        const filter4 = ExplorerService.getExplorersByStack(explorers, "elixir");
+
+        for(let i =0; i<filter.length; i++){expect(filter[i].stacks).toContain("javascript");}
+        for(let i =0; i<filter1.length; i++){expect(filter1[i].stacks).toContain("elm");}
+        for(let i =0; i<filter2.length; i++){expect(filter2[i].stacks).toContain("groovy");}
+        for(let i =0; i<filter3.length; i++){expect(filter3[i].stacks).toContain("reasonML");}
+        for(let i =0; i<filter4.length; i++){expect(filter4[i].stacks).toContain("elixir");}
     });
 
 });


### PR DESCRIPTION
La solución que pensé tenía que ver con checar si el explorer.stacks incluía o no el query param _"stacks"_ llámese javascript, groovy, elm, etc. Y si sí lo contenía regresar el explorer iterado al método filter que se estaba ejecutando.

Investigué otra solución que era checar si el query param existía o no dentro de explorer.stacks, usando un IndexOf, ya que si existe, tiene index y si no, no lo tiene, pero me quedé con la que había pensado por mi cuenta.