### PR TITLE
PR de contribución con nuevo endpoint de filtrado por stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -2,25 +2,31 @@ const ExplorerService = require("../services/ExplorerService");
 const FizzbuzzService = require("../services/FizzbuzzService");
 const Reader = require("../utils/reader");
 
-class ExplorerController{
-    static getExplorersByMission(mission){
-        const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.filterByMission(explorers, mission);
-    }
+class ExplorerController {
+  static getExplorersByMission(mission) {
+    const explorers = Reader.readJsonFile("explorers.json");
+    return ExplorerService.filterByMission(explorers, mission);
+  }
 
-    static applyFizzbuzz(score){
-        return FizzbuzzService.applyValidationInNumber(score);
-    }
+  static applyFizzbuzz(score) {
+    return FizzbuzzService.applyValidationInNumber(score);
+  }
 
-    static getExplorersUsernamesByMission(mission){
-        const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.getExplorersUsernamesByMission(explorers, mission);
-    }
+  static getExplorersUsernamesByMission(mission) {
+    const explorers = Reader.readJsonFile("explorers.json");
+    return ExplorerService.getExplorersUsernamesByMission(explorers, mission);
+  }
 
-    static getExplorersAmonutByMission(mission){
-        const explorers = Reader.readJsonFile("explorers.json");
-        return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
-    }
+  static getExplorersAmonutByMission(mission) {
+    const explorers = Reader.readJsonFile("explorers.json");
+    return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
+  }
+
+  static getExplorersByStack(stack) {
+    const explorers = Reader.readJsonFile("explorers.json");
+    const resultado = ExplorerService.getExplorersByStack(explorers, stack);
+    return resultado;
+  }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,38 +1,52 @@
 const ExplorerController = require("./controllers/ExplorerController");
 const express = require("express");
+const { query } = require("express");
 const app = express();
 app.use(express.json());
 const port = 3000;
 
 app.get("/", (request, response) => {
-    response.json({message: "FizzBuzz Api welcome!"});
+  response.json({ message: "FizzBuzz Api welcome!" });
 });
 
 app.get("/v1/explorers/:mission", (request, response) => {
-    const mission = request.params.mission;
-    const explorersInMission = ExplorerController.getExplorersByMission(mission);
-    response.json(explorersInMission);
+  const mission = request.params.mission;
+  const explorersInMission = ExplorerController.getExplorersByMission(mission);
+  response.json(explorersInMission);
 });
 
 app.get("/v1/explorers/amount/:mission", (request, response) => {
-    const mission = request.params.mission;
-    const explorersAmountInMission = ExplorerController.getExplorersAmonutByMission(mission);
-    response.json({mission: request.params.mission, quantity: explorersAmountInMission});
+  const mission = request.params.mission;
+  const explorersAmountInMission =
+    ExplorerController.getExplorersAmonutByMission(mission);
+  response.json({
+    mission: request.params.mission,
+    quantity: explorersAmountInMission,
+  });
 });
 
 app.get("/v1/explorers/usernames/:mission", (request, response) => {
-    const mission = request.params.mission;
-    const explorersUsernames = ExplorerController.getExplorersUsernamesByMission(mission);
-    response.json({mission: request.params.mission, explorers: explorersUsernames});
+  const mission = request.params.mission;
+  const explorersUsernames =
+    ExplorerController.getExplorersUsernamesByMission(mission);
+  response.json({
+    mission: request.params.mission,
+    explorers: explorersUsernames,
+  });
 });
 
 app.get("/v1/fizzbuzz/:score", (request, response) => {
-    const score = parseInt(request.params.score);
-    const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
-    response.json({score: score, trick: fizzbuzzTrick});
+  const score = parseInt(request.params.score);
+  const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
+  response.json({ score: score, trick: fizzbuzzTrick });
+});
+
+app.get("/v1/explorers/stack/:stack", (request, response) => {
+  const stack = request.params.stack;
+  const explorersByStack = ExplorerController.getExplorersByStack(stack);
+  response.json({ stack: stack, stacks: explorersByStack });
 });
 
 app.listen(port, () => {
-    console.log(`FizzBuzz API in localhost:${port}`);
+  console.log(`FizzBuzz API in localhost:${port}`);
 });
-

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -1,21 +1,46 @@
+const { text } = require("express");
+
 class ExplorerService {
+  static filterByMission(explorers, mission) {
+    const explorersByMission = explorers.filter(
+      (explorer) => explorer.mission == mission
+    );
+    return explorersByMission;
+  }
 
-    static filterByMission(explorers, mission){
-        const explorersByMission = explorers.filter((explorer) => explorer.mission == mission);
-        return explorersByMission;
-    }
+  static filterByStack(explorers, stack) {
+    const explorersByStack = explorers.filter((explorer) =>
+      explorer.stacks.includes(stack)
+    );
+    return explorersByStack;
+  }
 
-    static getAmountOfExplorersByMission(explorers, mission){
-        const explorersByMission = ExplorerService.filterByMission(explorers, mission);
-        return explorersByMission.length;
-    }
+  static getAmountOfExplorersByMission(explorers, mission) {
+    const explorersByMission = ExplorerService.filterByMission(
+      explorers,
+      mission
+    );
+    return explorersByMission.length;
+  }
 
-    static getExplorersUsernamesByMission(explorers, mission){
-        const explorersByMission = ExplorerService.filterByMission(explorers, mission);
-        const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
-        return explorersUsernames;
-    }
+  static getExplorersUsernamesByMission(explorers, mission) {
+    const explorersByMission = ExplorerService.filterByMission(
+      explorers,
+      mission
+    );
+    const explorersUsernames = explorersByMission.map(
+      (explorer) => explorer.githubUsername
+    );
+    return explorersUsernames;
+  }
 
+  static getExplorersByStack(explorers, stack) {
+    const explorersByStack = ExplorerService.filterByStack(explorers, stack);
+    const explorersName = explorersByStack.map(
+      (explorer) => explorer.name + ": " + explorer.stacks
+    );
+    return explorersName;
+  }
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,9 +1,7 @@
 const ExplorerController = require("./../../lib/controllers/ExplorerController");
-const ExplorerService = require("./../../lib/services/ExplorerService");
 describe("Test para ExplorerController", () => {
   test("1) Filtrar por stack", () => {
     const respuesta = ExplorerController.getExplorersByStack("javascript");
-    // expect(respuesta[1]).toMatch("javascript");
-    console.log(respuesta);
+    expect(respuesta[0]).toMatch("javascript");
   });
 });

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,9 @@
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+const ExplorerService = require("./../../lib/services/ExplorerService");
+describe("Test para ExplorerController", () => {
+  test("1) Filtrar por stack", () => {
+    const respuesta = ExplorerController.getExplorersByStack("javascript");
+    // expect(respuesta[1]).toMatch("javascript");
+    console.log(respuesta);
+  });
+});


### PR DESCRIPTION
El primer paso fue la creación de los nuevos métodos en el controlador ExplorerController.js y el servicio ExplorerService.js, agregué un método estático en ExplorerController (el cual recibe el stack para filtrado) para consumir el servicio ExplorerService.
En ExplorerService agregué un método estático que recibe la lista de explorers y el stack que será el criterio de filtrado. 
Esta función llama a su vez otra función que hace el filtrado de la lista de explorers con el stack como argumento, posteriormente se realiza un mapeo de este resultado para obtener el username y el stack de los usuarios con el stack de criterio seleccionado.
