### PR TITLE
endpoint nuevo que regresa toda la lista de explorers filtrados por un stack

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,11 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+    
+    static getExplorersByStack(mission){
+        const explorers= Reader.readJsonFile("explorers.json");
+        return ExplorerService.getExplorersByStack(explorers,mission);
+    }
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,14 @@ app.get("/v1/fizzbuzz/:score", (request, response) => {
     response.json({score: score, trick: fizzbuzzTrick});
 });
 
+// Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack
+// localhost:3000/v1/explorers/stack/javascript.
+app.get("/v1/explorers/stack/:mission", (req,res) => {
+    const mission= req.params.mission;
+    const ExplorersByStack = ExplorerController.getExplorersByStack(mission);
+    res.json(ExplorersByStack);
+});
+
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -15,7 +15,11 @@ class ExplorerService {
         const explorersUsernames = explorersByMission.map((explorer) => explorer.githubUsername);
         return explorersUsernames;
     }
-
+    
+    static getExplorersByStack(explorers,mission){
+        const explorerByStacks= explorers.filter((explorer) => explorer.stacks.includes(mission));
+        return explorerByStacks;
+    }
 }
 
 module.exports = ExplorerService;


### PR DESCRIPTION
Para hacer funcionar el nuevo enpoint de manera local despues de clonar el repositorio, hice los siguientes pasos:

1. Modifique el archivo package.json en la seccion de scripts, quedando de la siguiente manera:
  "scripts": {
    "start": "node index.js",
    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest",
    "linter": "node ./node_modules/eslint/bin/eslint.js .",
    "linter-fix": "node ./node_modules/eslint/bin/eslint.js . --fix",
    "server": "node ./lib/server.js"
  },
ya que uso el Windows 10 y asi como venia, tendria problemas de ejecucion

2. Instale la dependencia express con npm install express --save

3. En el archivo ExplorerService agregue un nuevo metodo estatico que recibe dos parametros:
static getExplorersByStack(explorers,mission)

4. En el archivo ExplorerController agregue otro metodo que solo recibe un parametro: 
static getExplorersByStack(mission){
y llama al metodo ExplorerService.getExplorerByStack, le manda el parametro que recibe y el otro se lo envia mediante una linea de codigo que llama a otro metodo para leer el archivo explorers.json

5. En el archivo server.js creo un endpoint con la url 
localhost:3000/v1/explorers/stack/:mission
el cual recibe la mision para el stack por query params y muestra la lista de explorers que cumplan la condicion

6. Corro linter y corrijo errores

7. Solo hago commit de los archivos que no generaran conflictos al hacer el fork
