### PR TITLE
Contribution Open Source to visual partnership - Mission Node JS - fizzbuzz

### DIFF
--- a/lib/controllers/ExplorerController.js
+++ b/lib/controllers/ExplorerController.js
@@ -21,6 +21,17 @@ class ExplorerController{
         const explorers = Reader.readJsonFile("explorers.json");
         return ExplorerService.getAmountOfExplorersByMission(explorers, mission);
     }
+
+
+
+    static getInStack(language){
+        const explorers = Reader.readJsonFile("explorers.json");
+        //const namesContainLanguage = ExplorerService.inStack(explorers,language);
+        //return namesContainLanguage;
+
+        return ExplorerService.inStack(explorers,language);
+    }
+
 }
 
 module.exports = ExplorerController;

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,13 +25,17 @@ app.get("/v1/explorers/usernames/:mission", (request, response) => {
     const explorersUsernames = ExplorerController.getExplorersUsernamesByMission(mission);
     response.json({mission: request.params.mission, explorers: explorersUsernames});
 });
-
 app.get("/v1/fizzbuzz/:score", (request, response) => {
     const score = parseInt(request.params.score);
     const fizzbuzzTrick = ExplorerController.applyFizzbuzz(score);
     response.json({score: score, trick: fizzbuzzTrick});
 });
-
+app.get("/v1/explorers/stack/:language", (request, response) => {
+    //const language = "javascript"
+    const language = parseInt(request.params.language);
+    const valor = ExplorerController.getInStack(request.params.language);
+    response.json({languageInStack: request.params.language, explorers: valor});
+});
 app.listen(port, () => {
     console.log(`FizzBuzz API in localhost:${port}`);
 });

--- a/lib/services/ExplorerService.js
+++ b/lib/services/ExplorerService.js
@@ -16,6 +16,13 @@ class ExplorerService {
         return explorersUsernames;
     }
 
+
+    static inStack(explorers, language){
+        const explorersInNodeToGetUsernames = explorers.filter((explorer) => explorer.stacks.includes(language));
+        const usernamesInNode = explorersInNodeToGetUsernames.map((explorer) => explorer.name);
+        return usernamesInNode;
+    }
+
 }
 
 module.exports = ExplorerService;

--- a/test/controllers/ExplorerController.test.js
+++ b/test/controllers/ExplorerController.test.js
@@ -1,0 +1,13 @@
+
+const ExplorerController = require("./../../lib/controllers/ExplorerController");
+//CODE TO CONTRIBUTION OPEN SOURCE - VISUALPARTNERSHIP
+describe("Requerimiento para ExplorerController", () => {
+    test("Requerimiento OPEN SOURCE: Regrese toda la lista de explorers filtrados por un stack.", () => {
+
+
+        //const resultController = ExplorerService.inStack(explorers, "javascript");
+        expect(ExplorerController.getInStack("javascript")).not.toBeUndefined();
+        expect(ExplorerController.getInStack("javascript").length).toBe(11);
+
+    });
+});

--- a/test/services/ExplorerService.test.js
+++ b/test/services/ExplorerService.test.js
@@ -7,4 +7,55 @@ describe("Tests para ExplorerService", () => {
         expect(explorersInNode.length).toBe(1);
     });
 
+    //CODE TO CONTRIBUTION OPEN SOURCE - VISUALPARTNERSHIP
+    test("Requerimiento OPEN SOURCE: regrese toda la lista de explorers filtrados por un stack.", () => {
+        const explorers =
+[
+    {
+        "name": "Woopa1",
+        "githubUsername": "ajolonauta1",
+        "score": 1,
+        "mission": "node",
+        "stacks": [
+            "javascript",
+            "reasonML",
+            "elm"
+        ]
+    },
+    {
+        "name": "Woopa2",
+        "githubUsername": "ajolonauta2",
+        "score": 2,
+        "mission": "node",
+        "stacks": [
+            "javascript",
+            "groovy",
+            "elm"
+        ]
+    },
+    {
+        "name": "Woopa3",
+        "githubUsername": "ajolonauta3",
+        "score": 3,
+        "mission": "node",
+        "stacks": [
+            "elixir",
+            "groovy",
+            "reasonML"
+        ]
+    }
+];
+
+
+
+
+        const explorersLanguage = ExplorerService.inStack(explorers, "javascript");
+        expect(explorersLanguage).not.toBeUndefined();
+        expect(explorersLanguage.length).toBe(2);
+        expect(explorersLanguage).toContain("Woopa1");
+        expect(explorersLanguage).toContain("Woopa2");
+    });
+
+
+
 });


### PR DESCRIPTION
Solución a: 
Crea un endpoint nuevo que regrese toda la lista de explorers filtrados por un stack.
Ejemplo de url: localhost:3000/v1/explorers/stack/javascript.
Response: Todos los explorers que tengan en stack el valor recibido en la url: javascript. (este valor debe ser dinámico)


-> La url puede ser modificada en el campo  'v1/explorers/stack/:language obteniendo el nombre de todos los explorers que cuentan dentro de su stack el lenguaje ingresado en la URL.

-> Debido a la indicación 'NO VERSIONAR PACKAGE.JSON' no se agregaron las dependencias para pruebas de unidad de servidor, manteniendo solo la version principal de la app de server.js con el código agregado.

-> Se usó Linter para limpieza de código.

